### PR TITLE
monitor CNI networks continuously

### DIFF
--- a/ocicni.go
+++ b/ocicni.go
@@ -55,9 +55,8 @@ func (plugin *cniNetworkPlugin) monitorNetDir() {
 				}
 
 				if err = plugin.syncNetworkConfig(); err == nil {
-					logrus.Debugf("CNI asynchronous setting succeeded")
-					close(plugin.monitorNetDirChan)
-					return
+					logrus.Infof("CNI asynchronous setting succeeded")
+					continue
 				}
 
 				logrus.Errorf("CNI setting failed, continue monitoring: %v", err)


### PR DESCRIPTION
Related to [#806](https://github.com/kubernetes-incubator/cri-o/pull/806) in `kubernetes-incubator/cri-o`

/cc @mrunalp

Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>