### PR TITLE
Return CNI Result from SetUpPod()

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -302,9 +302,9 @@ func (plugin *cniNetworkPlugin) Name() string {
 	return CNIPluginName
 }
 
-func (plugin *cniNetworkPlugin) SetUpPod(podNetwork PodNetwork) error {
+func (plugin *cniNetworkPlugin) SetUpPod(podNetwork PodNetwork) (cnitypes.Result, error) {
 	if err := plugin.checkInitialized(); err != nil {
-		return err
+		return nil, err
 	}
 
 	plugin.podLock(podNetwork).Lock()
@@ -313,16 +313,16 @@ func (plugin *cniNetworkPlugin) SetUpPod(podNetwork PodNetwork) error {
 	_, err := plugin.loNetwork.addToNetwork(podNetwork)
 	if err != nil {
 		logrus.Errorf("Error while adding to cni lo network: %s", err)
-		return err
+		return nil, err
 	}
 
-	_, err = plugin.getDefaultNetwork().addToNetwork(podNetwork)
+	result, err := plugin.getDefaultNetwork().addToNetwork(podNetwork)
 	if err != nil {
 		logrus.Errorf("Error while adding to cni network: %s", err)
-		return err
+		return nil, err
 	}
 
-	return err
+	return result, err
 }
 
 func (plugin *cniNetworkPlugin) TearDownPod(podNetwork PodNetwork) error {

--- a/pkg/ocicni/types.go
+++ b/pkg/ocicni/types.go
@@ -1,5 +1,9 @@
 package ocicni
 
+import (
+	"github.com/containernetworking/cni/pkg/types"
+)
+
 const (
 	// DefaultInterfaceName is the string to be used for the interface name inside the net namespace
 	DefaultInterfaceName = "eth0"
@@ -49,7 +53,7 @@ type CNIPlugin interface {
 	// SetUpPod is the method called after the sandbox container of
 	// the pod has been created but before the other containers of the
 	// pod are launched.
-	SetUpPod(network PodNetwork) error
+	SetUpPod(network PodNetwork) (types.Result, error)
 
 	// TearDownPod is the method called before a pod's sandbox container will be deleted
 	TearDownPod(network PodNetwork) error


### PR DESCRIPTION
Runtimes and tools may want to do things like print interface and IP details after setting up the sandbox, so make sure they can do this by returning the CNI result.

@mrunalp @rajatchopra 