### PR TITLE
Support IPv6.

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -344,6 +344,9 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatus(podNetwork PodNetwork) (stri
 
 	ip, err := getContainerIP(plugin.nsenterPath, podNetwork.NetNS, DefaultInterfaceName, "-4")
 	if err != nil {
+		ip, err = getContainerIP(plugin.nsenterPath, podNetwork.NetNS, DefaultInterfaceName, "-6")
+	}
+	if err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
Support IPv6.
Ref https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/network/plugins.go#L290.
For https://github.com/containerd/cri-containerd/issues/580.

Signed-off-by: Lantao Liu <lantaol@google.com>