### PR TITLE
Tolerant netdir not exist

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -173,9 +173,9 @@ func InitCNI(pluginDir string, cniDirs ...string) (CNIPlugin, error) {
 		return nil, err
 	}
 
-	// Fail loudly if plugin directory doesn't exist, because fsnotify watcher
-	// won't be able to watch it.
-	if _, err := os.Stat(pluginDir); err != nil {
+	// Ensure plugin directory exists, because the following monitoring logic
+	// relies on that.
+	if err := os.MkdirAll(pluginDir); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Based on https://github.com/cri-o/ocicni/pull/13, will rebase after it is merged.

Part of https://github.com/containerd/cri-containerd/issues/573.

It's normal that when `cri-containerd` or `cri-o` start, cni network config directory is not created yet. In today's kubernetes, it's usually network plugin's responsibility to create the config directory.

We should not error out in that case.