### PR TITLE
pkg/ocicni: cross-platform paths

### DIFF
--- a/pkg/ocicni/types.go
+++ b/pkg/ocicni/types.go
@@ -9,12 +9,6 @@ const (
 	DefaultInterfaceName = "eth0"
 	// CNIPluginName is the default name of the plugin
 	CNIPluginName = "cni"
-	// DefaultNetDir is the place to look for CNI Network
-	DefaultNetDir = "/etc/cni/net.d"
-	// DefaultCNIDir is the place to look for cni config files
-	DefaultCNIDir = "/opt/cni/bin"
-	// VendorCNIDirTemplate is the template for looking up vendor specific cni config/executable files
-	VendorCNIDirTemplate = "%s/opt/%s/bin"
 )
 
 // PortMapping maps to the standard CNI portmapping Capability

--- a/pkg/ocicni/types_unix.go
+++ b/pkg/ocicni/types_unix.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package ocicni
+
+const (
+	// DefaultNetDir is the place to look for CNI Network
+	DefaultNetDir = "/etc/cni/net.d"
+	// DefaultCNIDir is the place to look for cni config files
+	DefaultCNIDir = "/opt/cni/bin"
+	// VendorCNIDirTemplate is the template for looking up vendor specific cni config/executable files
+	VendorCNIDirTemplate = "%s/opt/%s/bin"
+)

--- a/pkg/ocicni/types_windows.go
+++ b/pkg/ocicni/types_windows.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package ocicni
+
+const (
+	// DefaultNetDir is the place to look for CNI Network
+	DefaultNetDir = "C:\\cni\\etc\\net.d"
+	// DefaultCNIDir is the place to look for cni config files
+	DefaultCNIDir = "C:\\cni\\bin"
+	// VendorCNIDirTemplate is the template for looking up vendor specific cni config/executable files
+	VendorCNIDirTemplate = "C:\\cni\\%s\\opt\\%s\\bin" // XXX(vbatts) Not sure what to do here ...
+)


### PR DESCRIPTION
some of these default paths are not unix only

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>