### PR TITLE
Make GetDefaultNetwork publically exposed via Plugin

### DIFF
--- a/pkg/ocicni/types.go
+++ b/pkg/ocicni/types.go
@@ -61,6 +61,10 @@ type CNIPlugin interface {
 	// for a plugin by name, e.g.
 	Name() string
 
+	// GetDefaultNetworkName returns the name of the plugin's default
+	// network.
+	GetDefaultNetworkName() string
+
 	// SetUpPod is the method called after the sandbox container of
 	// the pod has been created but before the other containers of the
 	// pod are launched.


### PR DESCRIPTION
Allow consumers of ocicni to check the default network of the plugins.

Fixes a bug in #23 where the function was made public but not added to the interface.