### PR TITLE
support to reload CNI configs real-time if defaultNetName is not assigned in initialization

### DIFF
--- a/pkg/ocicni/ocicni_test.go
+++ b/pkg/ocicni/ocicni_test.go
@@ -251,11 +251,11 @@ var _ = Describe("ocicni operations", func() {
 		ocicni.Shutdown()
 	})
 
-	It("finds an the asciibetically first network configuration as default if given no default network name", func() {
+	It("finds an ASCIIbetically first network configuration as default if given no default network name", func() {
 		ocicni, err := InitCNI("", tmpDir, "/opt/cni/bin")
 		Expect(err).NotTo(HaveOccurred())
 
-		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "myplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "15-test.conf", "test", "myplugin", "0.3.1")
 		Expect(err).NotTo(HaveOccurred())
 		_, _, err = writeConfig(tmpDir, "5-notdefault.conf", "notdefault", "myplugin", "0.3.1")
 		Expect(err).NotTo(HaveOccurred())
@@ -265,6 +265,16 @@ var _ = Describe("ocicni operations", func() {
 		tmp := ocicni.(*cniNetworkPlugin)
 		net := tmp.getDefaultNetwork()
 		Expect(net.name).To(Equal("test"))
+		Expect(len(net.NetworkConfig.Plugins)).To(BeNumerically(">", 0))
+		Expect(net.NetworkConfig.Plugins[0].Network.Type).To(Equal("myplugin"))
+
+		_, _, err = writeConfig(tmpDir, "10-abc.conf", "newdefault", "myplugin", "0.3.1")
+		Expect(err).NotTo(HaveOccurred())
+
+		Consistently(ocicni.Status, 5).Should(Succeed())
+
+		net = tmp.getDefaultNetwork()
+		Expect(net.name).To(Equal("newdefault"))
 		Expect(len(net.NetworkConfig.Plugins)).To(BeNumerically(">", 0))
 		Expect(net.NetworkConfig.Plugins[0].Network.Type).To(Equal("myplugin"))
 


### PR DESCRIPTION
When we use ocicni in our CRI (pouch), we found that CNI configs can not be reloaded real-time because the first ASCIIbetically network config's name will be **defaultNetName** forever after initialization , a new CNI config with new name and high-sort-order will not be updated to **defaultNetName** unless we restarts CRI. I don't think it's a proper behavior we expect.

And I think what we expect is that **if defaultNetName is not empty**, a CNI config with that network name will be used as the default CNI network, and container network operations will fail until that network config with specific defaultNetName is present and valid. But **if defaultNetName is empty**, CNI config should be loaded real-time and defaultNetName should be determined by file sorting, just like kubernetes cniNetworkPlugin, this will avoid CRI restarts when we want to import a new CNI config.
I hope this pr will have some help for above.