### PR TITLE
Add approvers to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,3 +2,8 @@ assignees:
   - rajatchopra
   - sameo
   - dcbw
+approvers:
+  - rajatchopra
+  - sameo
+  - dcbw
+  - mrunalp


### PR DESCRIPTION
per https://github.com/cri-o/ocicni/pull/28, It seems PRs can't be merged by the openshift merge bot, as OWNERS doesn't have an approver field like: https://github.com/cri-o/cri-o/blob/master/OWNERS

Add approvers field so PRs can be merged by the bot

Signed-off-by: Peter Hunt <pehunt@redhat.com>