### PR TITLE
support podCIDR in cniNetworkPlugin

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -554,10 +554,12 @@ func buildCNIRuntimeConf(cacheDir string, podNetwork *PodNetwork, ifName string,
 		rt.Args = append(rt.Args, [2]string{"IP", ip})
 	}
 
+	// Set PortMappings in Capabilities
 	if len(runtimeConfig.PortMappings) != 0 {
 		rt.CapabilityArgs["portMappings"] = runtimeConfig.PortMappings
 	}
 
+	// Set Bandwidth in Capabilities
 	if runtimeConfig.Bandwidth != nil {
 		rt.CapabilityArgs["bandwidth"] = map[string]uint64{
 			"ingressRate":  runtimeConfig.Bandwidth.IngressRate,
@@ -565,6 +567,11 @@ func buildCNIRuntimeConf(cacheDir string, podNetwork *PodNetwork, ifName string,
 			"egressRate":   runtimeConfig.Bandwidth.EgressRate,
 			"egressBurst":  runtimeConfig.Bandwidth.EgressBurst,
 		}
+	}
+
+	// Set IpRanges in Capabilities
+	if len(runtimeConfig.IpRanges) > 0 {
+		rt.CapabilityArgs["ipRanges"] = runtimeConfig.IpRanges
 	}
 
 	return rt, nil

--- a/pkg/ocicni/types.go
+++ b/pkg/ocicni/types.go
@@ -24,6 +24,19 @@ type PortMapping struct {
 	HostIP string `json:"hostIP"`
 }
 
+// IpRange maps to the standard CNI ipRanges Capability
+// see: https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md
+type IpRange struct {
+	// Subnet is the whole CIDR
+	Subnet string `json:"subnet"`
+	// RangeStart is the first available IP in subnet
+	RangeStart string `json:"rangeStart,omitempty"`
+	// RangeEnd is the last available IP in subnet
+	RangeEnd string `json:"rangeEnd,omitempty"`
+	// Gateway is the gateway of subnet
+	Gateway string `json:"gateway,omitempty"`
+}
+
 // RuntimeConfig is additional configuration for a single CNI network that
 // is pod-specific rather than general to the network.
 type RuntimeConfig struct {
@@ -35,8 +48,12 @@ type RuntimeConfig struct {
 	PortMappings []PortMapping
 	// Bandwidth is the bandwidth limiting of the pod
 	Bandwidth *BandwidthConfig
+	// IpRanges is the ip range gather which is used for address allocation
+	IpRanges [][]IpRange
 }
 
+// BandwidthConfig maps to the standard CNI bandwidth Capability
+// see: https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md
 type BandwidthConfig struct {
 	// IngressRate is a limit for incoming traffic in bps
 	IngressRate  uint64


### PR DESCRIPTION
Make cniNetworkPlugin support to receive and store podCIDR from CRI, and pass it to CNI plugins correctly.

ref #33 