### PR TITLE
Fix default network not being set when priority changes

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -334,11 +334,9 @@ func (plugin *cniNetworkPlugin) syncNetworkConfig() error {
 	}
 
 	plugin.Lock()
-	defer plugin.Unlock()
-	if plugin.defaultNetName == "" {
-		plugin.defaultNetName = defaultNetName
-	}
+	plugin.defaultNetName = defaultNetName
 	plugin.networks = networks
+	plugin.Unlock()
 
 	return nil
 }

--- a/pkg/ocicni/ocicni_test.go
+++ b/pkg/ocicni/ocicni_test.go
@@ -190,7 +190,7 @@ var _ = Describe("ocicni operations", func() {
 		// Writing a config that doesn't match the default network
 		_, _, err = writeConfig(tmpDir, "5-notdefault.conf", "notdefault", "myplugin")
 		Expect(err).NotTo(HaveOccurred())
-		Consistently(ocicni.Status, 5).Should(HaveOccurred())
+		Eventually(ocicni.Status, 5).Should(HaveOccurred())
 
 		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "myplugin")
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
If the priorities (sorted by name) of the configured networks change,
then the default network needs to be adapted to ensure it is actually
being used.

/cc @haircommander @mrunalp 

This fix seems a bit critical to me since changing the network priority
on the fly currently does not work in CRI-O. It would be awesome if
we could tag a new release afterwards :innocent: 