### PR TITLE
When syncNetworkConfig we should update defaultNetName to avoid  getDefaultNetwork error

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -335,9 +335,7 @@ func (plugin *cniNetworkPlugin) syncNetworkConfig() error {
 
 	plugin.Lock()
 	defer plugin.Unlock()
-	if plugin.defaultNetName == "" {
-		plugin.defaultNetName = defaultNetName
-	}
+	plugin.defaultNetName = defaultNetName
 	plugin.networks = networks
 
 	return nil


### PR DESCRIPTION
When conf file change, especially ```confList.Name``` changed, by ```loadNetworks``` func, we can get a new networks and defaultNetname. In now, if defaultNetname not empty, we will not update it , if like so,  we will  get nil when we call  ```getDefaultNetwork``` func, because of the network which name is defaultNetname not exist. and if we call ```status``` func ,we will get 'Missing CNI default network' 