### PR TITLE
ocicni: ensure returned CHECK results are the same CNIVersion as config

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -562,7 +562,13 @@ func (network *cniNetwork) checkNetwork(cacheDir string, podNetwork *PodNetwork,
 		IPs:        ips,
 	}
 
-	return result, nil
+	// Result must be the same CNIVersion as the CNI config
+	converted, err := result.GetAsVersion(netconf.CNIVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	return converted, nil
 }
 
 func (network *cniNetwork) deleteFromNetwork(cacheDir string, podNetwork *PodNetwork, ifName string, runtimeConfig RuntimeConfig) error {

--- a/pkg/ocicni/ocicni_test.go
+++ b/pkg/ocicni/ocicni_test.go
@@ -603,7 +603,11 @@ var _ = Describe("ocicni operations", func() {
 
 		resultsStatus, errStatus := ocicni.GetPodNetworkStatus(podNet)
 		Expect(errStatus).NotTo(HaveOccurred())
-		Expect(resultsStatus).NotTo(Equal(nil))
+		Expect(len(resultsStatus)).To(Equal(2))
+		r = resultsStatus[0].(*current.Result)
+		Expect(reflect.DeepEqual(r, expectedResult1)).To(BeTrue())
+		r = resultsStatus[1].(*current.Result)
+		Expect(reflect.DeepEqual(r, expectedResult2)).To(BeTrue())
 
 		err = ocicni.TearDownPod(podNet)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Results must always be the same CNIVersion as the incoming CNI config.

Signed-off-by: Dan Williams <dcbw@redhat.com>

@mccv1r0 