### PR TITLE
Update the internal localhost CNI to v0.3.1

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -307,7 +307,7 @@ func loadNetworks(exec cniinvoke.Exec, confDir string, binDirs []string) (map[st
 
 func getLoNetwork(exec cniinvoke.Exec, binDirs []string) *cniNetwork {
 	loConfig, err := libcni.ConfListFromBytes([]byte(`{
-  "cniVersion": "0.2.0",
+  "cniVersion": "0.3.1",
   "name": "cni-loopback",
   "plugins": [{
     "type": "loopback"

--- a/pkg/ocicni/ocicni_test.go
+++ b/pkg/ocicni/ocicni_test.go
@@ -55,7 +55,7 @@ type TestConf struct {
 func (f *fakeExec) addLoopback() {
 	f.plugins = append(f.plugins, &fakePlugin{
 		expectedConf: `{
-        "cniVersion": "0.2.0",
+        "cniVersion": "0.3.1",
         "name": "cni-loopback",
         "type": "loopback"
 }`,


### PR DESCRIPTION
We should stay up to date with the CNI versions to avoid compatibility
clashes in the future.
