### PR TITLE
Avoid to overwrite network in loadNetworks()

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -305,7 +305,11 @@ func loadNetworks(confDir string, cni *libcni.CNIConfig) (map[string]*cniNetwork
 
 		logrus.Infof("Found CNI network %s (type=%v) at %s", confList.Name, confList.Plugins[0].Network.Type, confFile)
 
-		networks[confList.Name] = cniNet
+		if _, ok := networks[confList.Name]; !ok {
+			networks[confList.Name] = cniNet
+		} else {
+			logrus.Infof("Ignore CNI network %s (type=%v) at %s because already exists", confList.Name, confList.Plugins[0].Network.Type, confFile)
+		}
 
 		if defaultNetName == "" {
 			defaultNetName = confList.Name

--- a/pkg/ocicni/ocicni_test.go
+++ b/pkg/ocicni/ocicni_test.go
@@ -315,12 +315,12 @@ var _ = Describe("ocicni operations", func() {
 		netMap, _, err := loadNetworks(tmpDir, cniConfig)
 		Expect(err).NotTo(HaveOccurred())
 
-		// We expect the type=myplugin network to be ignored since it
-		// was read earlier than the type=myplugin2 network with the same name
+		// We expect the type=myplugin2 network be ignored since it
+		// was read earlier than the type=myplugin network with the same name
 		Expect(len(netMap)).To(Equal(2))
 		net, ok := netMap["network2"]
 		Expect(ok).To(BeTrue())
-		Expect(net.config.Plugins[0].Network.Type).To(Equal("myplugin2"))
+		Expect(net.config.Plugins[0].Network.Type).To(Equal("myplugin"))
 	})
 
 	It("build different runtime configs", func() {


### PR DESCRIPTION
If there are several CNI config files with same name, ocicni
overwrite network hence the last one becomes default network.
This fix is avoid to overwrite it.