### PR TITLE
reload default CNI network name real-time if it is not assigned in initialization

### DIFF
--- a/pkg/ocicni/ocicni_test.go
+++ b/pkg/ocicni/ocicni_test.go
@@ -281,11 +281,11 @@ var _ = Describe("ocicni operations", func() {
 		ocicni.Shutdown()
 	})
 
-	It("finds an the asciibetically first network configuration as default if given no default network name", func() {
+	It("finds an ASCIIbetically first network configuration as default real-time if given no default network name", func() {
 		ocicni, err := initCNI(&fakeExec{}, "", "", tmpDir, "/opt/cni/bin")
 		Expect(err).NotTo(HaveOccurred())
 
-		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "myplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "15-test.conf", "test", "myplugin", "0.3.1")
 		Expect(err).NotTo(HaveOccurred())
 		_, _, err = writeConfig(tmpDir, "5-notdefault.conf", "notdefault", "myplugin", "0.3.1")
 		Expect(err).NotTo(HaveOccurred())
@@ -295,6 +295,18 @@ var _ = Describe("ocicni operations", func() {
 		tmp := ocicni.(*cniNetworkPlugin)
 		net := tmp.getDefaultNetwork()
 		Expect(net.name).To(Equal("test"))
+		Expect(len(net.config.Plugins)).To(BeNumerically(">", 0))
+		Expect(net.config.Plugins[0].Network.Type).To(Equal("myplugin"))
+
+		// If a new CNI config file is added, default network name should be reloaded real-time
+		// by file sorting
+		_, _, err = writeConfig(tmpDir, "10-abc.conf", "newdefault", "myplugin", "0.3.1")
+		Expect(err).NotTo(HaveOccurred())
+
+		Consistently(ocicni.Status, 5).Should(Succeed())
+
+		net = tmp.getDefaultNetwork()
+		Expect(net.name).To(Equal("newdefault"))
 		Expect(len(net.config.Plugins)).To(BeNumerically(">", 0))
 		Expect(net.config.Plugins[0].Network.Type).To(Equal("myplugin"))
 


### PR DESCRIPTION
ref to #31 

I think the preconditions (del from cache) have been met in #56 , so we can go on promoting this, and for clarity, I pull a new request...

@dcbw @haircommander @mrunalp 

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>