### PR TITLE
ocicni: add support of specifying static MACs

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -819,6 +819,16 @@ func buildCNIRuntimeConf(cacheDir string, podNetwork *PodNetwork, ifName string,
 		rt.Args = append(rt.Args, [2]string{"IP", ip})
 	}
 
+	// Add the requested static MAC to CNI_ARGS
+	mac := runtimeConfig.MAC
+	if mac != "" {
+		_, err := net.ParseMAC(mac)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse MAC address %q: %v", mac, err)
+		}
+		rt.Args = append(rt.Args, [2]string{"MAC", mac})
+	}
+
 	// Set PortMappings in Capabilities
 	if len(runtimeConfig.PortMappings) != 0 {
 		rt.CapabilityArgs["portMappings"] = runtimeConfig.PortMappings

--- a/pkg/ocicni/ocicni_test.go
+++ b/pkg/ocicni/ocicni_test.go
@@ -393,6 +393,26 @@ var _ = Describe("ocicni operations", func() {
 		Expect(len(rt.Args)).To(Equal(5))
 		Expect(rt.Args[4][1]).To(Equal("172.16.0.1"))
 
+		// runtimeConfig with invalid MAC
+		runtimeConfig = RuntimeConfig{MAC: "f0:a6"}
+		_, err = buildCNIRuntimeConf(cacheDir, podNetwork, ifName, runtimeConfig)
+		Expect(err).To(HaveOccurred())
+
+		// runtimeConfig with valid MAC
+		runtimeConfig = RuntimeConfig{MAC: "9e:0c:d9:b2:f0:a6"}
+		rt, err = buildCNIRuntimeConf(cacheDir, podNetwork, ifName, runtimeConfig)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(rt.Args)).To(Equal(5))
+		Expect(rt.Args[4][1]).To(Equal("9e:0c:d9:b2:f0:a6"))
+
+		// runtimeConfig with valid IP and valid MAC
+		runtimeConfig = RuntimeConfig{IP: "172.16.0.1", MAC: "9e:0c:d9:b2:f0:a6"}
+		rt, err = buildCNIRuntimeConf(cacheDir, podNetwork, ifName, runtimeConfig)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(rt.Args)).To(Equal(6))
+		Expect(rt.Args[4][1]).To(Equal("172.16.0.1"))
+		Expect(rt.Args[5][1]).To(Equal("9e:0c:d9:b2:f0:a6"))
+
 		// runtimeConfig with portMappings is nil
 		runtimeConfig = RuntimeConfig{PortMappings: nil}
 		_, err = buildCNIRuntimeConf(cacheDir, podNetwork, ifName, runtimeConfig)

--- a/pkg/ocicni/types.go
+++ b/pkg/ocicni/types.go
@@ -44,6 +44,9 @@ type RuntimeConfig struct {
 	// with the hostlocal IP allocator. If left unset, an IP will be
 	// dynamically allocated.
 	IP string
+	// MAC is a static MAC address to be assigned to the network interface.
+	// If left unset, a MAC will be dynamically allocated.
+	MAC string
 	// PortMappings is the port mapping of the sandbox.
 	PortMappings []PortMapping
 	// Bandwidth is the bandwidth limiting of the pod


### PR DESCRIPTION
Add the parameter MAC to CNI_ARGS.

I copied the approach from the plugin tunning and github.com/intel/multus-cni.