### PR TITLE
monitorConfDir should continue even with watcher errors

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -175,11 +175,7 @@ func (plugin *cniNetworkPlugin) monitorConfDir(start *sync.WaitGroup) {
 			}
 
 		case err := <-plugin.watcher.Errors:
-			if err == nil {
-				continue
-			}
 			logrus.Errorf("CNI monitoring error %v", err)
-			return
 
 		case <-plugin.shutdownChan:
 			return


### PR DESCRIPTION
If there are any watcher errors then the monitorConfDir goroutine will exit. Exiting this monitor loop is likely undesirable. 