### PR TITLE
Add API to access CNI networks

### DIFF
--- a/pkg/ocicni/types.go
+++ b/pkg/ocicni/types.go
@@ -133,4 +133,7 @@ type CNIPlugin interface {
 
 	// Shutdown terminates all driver operations
 	Shutdown() error
+
+	// Networks returns the list of currently loaded CNI networks
+	Networks() []CNINetwork
 }


### PR DESCRIPTION
This allows us to have more information about the current CNI
configuration, which enables API consumers to reject configurations if
needed.
