### PR TITLE
Propagate existing CNI_ARGS to non-k8s consumers, e.g., podman

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -809,6 +809,13 @@ func buildCNIRuntimeConf(cacheDir string, podNetwork *PodNetwork, ifName string,
 		CapabilityArgs: map[string]interface{}{},
 	}
 
+	// Propagate CNI_ARGS for non-k8s consumers, e.g., podman
+	for _, kvpairs := range strings.Split(os.Getenv("CNI_ARGS"), ";"){
+		if keyval := strings.Split(kvpairs, "="); len(keyval) == 2 {
+			rt.Args = append(rt.Args, [2]string{keyval[0], keyval[1]})
+		}
+	}
+
 	// Add requested static IP to CNI_ARGS
 	ip := runtimeConfig.IP
 	if ip != "" {


### PR DESCRIPTION
Addresses #65.

Propagate any existing CNI_ARGS for non-k8s consumers, like podman. 

Affected consumer issue: https://github.com/containers/libpod/issues/4398