### PR TITLE
Propagate existing CNI_ARGS to non-k8s consumers, e.g., podman

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -811,7 +811,7 @@ func buildCNIRuntimeConf(cacheDir string, podNetwork *PodNetwork, ifName string,
 
 	// Propagate existing CNI_ARGS to non-k8s consumers
 	for _, kvpairs := range strings.Split(os.Getenv("CNI_ARGS"), ";"){
-		if keyval := strings.Split(kvpairs, "="); len(keyval) == 2 {
+		if keyval := strings.SplitN(kvpairs, "=", 2); len(keyval) == 2 {
 			rt.Args = append(rt.Args, [2]string{keyval[0], keyval[1]})
 		}
 	}

--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -809,6 +809,13 @@ func buildCNIRuntimeConf(cacheDir string, podNetwork *PodNetwork, ifName string,
 		CapabilityArgs: map[string]interface{}{},
 	}
 
+	// Propagate existing CNI_ARGS to non-k8s consumers
+	for _, kvpairs := range strings.Split(os.Getenv("CNI_ARGS"), ";"){
+		if keyval := strings.Split(kvpairs, "="); len(keyval) == 2 {
+			rt.Args = append(rt.Args, [2]string{keyval[0], keyval[1]})
+		}
+	}
+
 	// Add requested static IP to CNI_ARGS
 	ip := runtimeConfig.IP
 	if ip != "" {


### PR DESCRIPTION
Let's try again.  Add existing CNI_ARGS in the environment to rt.Args in case the caller is a non-k8s consumer like podman.

Addresses #65 

