### PR TITLE
Pass aliases to CNI

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -912,6 +912,10 @@ func buildCNIRuntimeConf(cacheDir string, podNetwork *PodNetwork, ifName string,
 		rt.CapabilityArgs["ipRanges"] = runtimeConfig.IpRanges
 	}
 
+	// Set Aliases in Capabilities
+	if len(podNetwork.Aliases) > 0 {
+		rt.CapabilityArgs["aliases"] = podNetwork.Aliases
+	}
 	return rt, nil
 }
 

--- a/pkg/ocicni/types.go
+++ b/pkg/ocicni/types.go
@@ -89,6 +89,11 @@ type PodNetwork struct {
 	// It is optional, and can be omitted for some or all specified networks
 	// without issue.
 	RuntimeConfig map[string]RuntimeConfig
+
+	// Aliases are network-scoped names for resolving a container
+	// by name. The key value is the network name and the value is
+	// is a string slice of aliases
+	Aliases map[string][]string
 }
 
 // NetAttachment describes a container network attachment


### PR DESCRIPTION
network aliases have become a hard requirement for Podman and we need to
be able to pass them through ocicni to CNI plugins.  we do so by tucking
them in runtime capabilities args much like other things are done.  this
is required for docker compatibility on the podman side as well.

Signed-off-by: baude <bbaude@redhat.com>