### PR TITLE
move netlink funcs and create stubs

### DIFF
--- a/pkg/ocicni/util_unsupported.go
+++ b/pkg/ocicni/util_unsupported.go
@@ -3,17 +3,32 @@
 package ocicni
 
 import (
-	"fmt"
+	"errors"
 	"net"
 )
 
 type nsManager struct {
 }
 
+var errUnsupportedPlatform = errors.New("unsupported platform")
+
 func (nsm *nsManager) init() error {
 	return nil
 }
 
 func getContainerDetails(nsm *nsManager, netnsPath, interfaceName, addrType string) (*net.IPNet, *net.HardwareAddr, error) {
-	return nil, nil, fmt.Errorf("not supported yet")
+	return nil, nil, errUnsupportedPlatform
+}
+
+func tearDownLoopback(netns string) error {
+	return errUnsupportedPlatform
+}
+
+func bringUpLoopback(netns string) error {
+	return errUnsupportedPlatform
+}
+
+func checkLoopback(netns string) error {
+	return errUnsupportedPlatform
+
 }


### PR DESCRIPTION
Projects that vendor types from ocicni and also must support darwin and
windows fail to build due to the netlink package.  To avoid this, move
the funcs in question into _linux and create stubs in _unsupported.

No code changes to the functions were made.

```release-note
NONE
```

Signed-off-by: baude <bbaude@redhat.com>