### PR TITLE
Only warn if there is an actuall configuration problem

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -149,7 +149,7 @@ func (plugin *cniNetworkPlugin) monitorConfDir(start *sync.WaitGroup) {
 	for {
 		select {
 		case event := <-plugin.watcher.Events:
-			logrus.Warningf("CNI monitoring event %v", event)
+			logrus.Infof("CNI monitoring event %v", event)
 
 			var defaultDeleted bool
 			createWrite := (event.Op&fsnotify.Create == fsnotify.Create ||
@@ -295,7 +295,7 @@ func loadNetworks(confDir string, cni *libcni.CNIConfig) (map[string]*cniNetwork
 			}
 		}
 		if len(confList.Plugins) == 0 {
-			logrus.Warningf("CNI config list %s has no networks, skipping", confFile)
+			logrus.Infof("CNI config list %s has no networks, skipping", confFile)
 			continue
 		}
 
@@ -350,7 +350,7 @@ func (plugin *cniNetworkPlugin) syncNetworkConfig() error {
 		plugin.defaultNetName.name = defaultNetName
 		logrus.Infof("Update default CNI network name to %s", defaultNetName)
 	} else {
-		logrus.Warnf("Default CNI network name %s is unchangeable", plugin.defaultNetName.name)
+		logrus.Debugf("Default CNI network name %s is unchangeable", plugin.defaultNetName.name)
 	}
 
 	plugin.networks = networks


### PR DESCRIPTION
We are trying to drop Podman logrus level to "warn".  But the ocicni
log level by default prints out a Warning message on every run.

sudo podman --log-level=warn run alpine echo hello
[sudo] password for dwalsh:
WARN[0000] Default CNI network name podman is unchangeable
hello

Since this is an expected behaviour, not a mis configuraiton, it should
be dropped to Info. We should only print Warnings, when there is actuall
configuration errors or changes the user could act upon.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>