### PR TITLE
Remove error logging for deleteFromNetwork call

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -637,8 +637,7 @@ func (plugin *cniNetworkPlugin) TearDownPodWithContext(ctx context.Context, podN
 
 	return plugin.forEachNetwork(&podNetwork, true, func(network *cniNetwork, podNetwork *PodNetwork, rt *libcni.RuntimeConf) error {
 		if err := network.deleteFromNetwork(ctx, rt, plugin.cniConfig); err != nil {
-			logrus.Errorf("Error while removing pod from CNI network %q: %s", network.name, err)
-			return err
+			return fmt.Errorf("Error while removing pod from CNI network %q: %s", network.name, err)
 		}
 		return nil
 	})
@@ -771,7 +770,6 @@ func (network *cniNetwork) checkNetwork(ctx context.Context, rt *libcni.RuntimeC
 func (network *cniNetwork) deleteFromNetwork(ctx context.Context, rt *libcni.RuntimeConf, cni *libcni.CNIConfig) error {
 	logrus.Infof("About to del CNI network %s (type=%v)", network.name, network.config.Plugins[0].Network.Type)
 	if err := cni.DelNetworkList(ctx, network.config, rt); err != nil {
-		logrus.Errorf("Error deleting network %s: %v", network.name, err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
While working on containers/podman#8571 I noticed that calling `deleteFromNetwork`
logs the same error twice. It errors for example if the iptables rules do
not exists and create a very verbose error. Since the error is returned
I do not see any point in logging it. The caller should decide if the
error should be logged or not.

It is super confusing for users to get a error logged when they have no
control to change anything. In case of containers/podman#8571 the user would only want
to call this if the iptables rules are flushed, getting a error in this case
is super confusing.