### PR TITLE
Silence ENOENT errors and sync networks if no match is found

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -495,8 +495,15 @@ func (plugin *cniNetworkPlugin) forEachNetwork(podNetwork *PodNetwork, fromCache
 		if cniNet == nil {
 			cniNet, err = plugin.getNetwork(network.Name)
 			if err != nil {
-				logrus.Errorf(err.Error())
-				return err
+				// try to load the networks again
+				if err2 := plugin.syncNetworkConfig(); err2 != nil {
+					logrus.Error(err2)
+					return err
+				}
+				cniNet, err = plugin.getNetwork(network.Name)
+				if err != nil {
+					return err
+				}
 			}
 		}
 

--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -275,13 +275,19 @@ func loadNetworks(confDir string, cni *libcni.CNIConfig) (map[string]*cniNetwork
 		if strings.HasSuffix(confFile, ".conflist") {
 			confList, err = libcni.ConfListFromFile(confFile)
 			if err != nil {
-				logrus.Errorf("Error loading CNI config list file %s: %v", confFile, err)
+				// do not log ENOENT errors
+				if !os.IsNotExist(err) {
+					logrus.Errorf("Error loading CNI config list file %s: %v", confFile, err)
+				}
 				continue
 			}
 		} else {
 			conf, err := libcni.ConfFromFile(confFile)
 			if err != nil {
-				logrus.Errorf("Error loading CNI config file %s: %v", confFile, err)
+				// do not log ENOENT errors
+				if !os.IsNotExist(err) {
+					logrus.Errorf("Error loading CNI config file %s: %v", confFile, err)
+				}
 				continue
 			}
 			if conf.Network.Type == "" {


### PR DESCRIPTION
Do not print ENOENT errors when loading networks
The files has been removed there is no need to log a error
we can simply ignore it.

Reload networks if none is found
In the podman CI tests are consistently flaking with CNI network not
found ... I think the problem is that ocicni updates based on fsnotify
and this can be slower than the podman calls.
As a solution the networks should be synced if no match is found. If
it is still not found afterwards return the network not found error.

I tested this in the podman https://github.com/containers/podman/pull/9449 and I didn't saw the described flakes in the remote integration tests.

```release-note
ENOENT errors are no longer logged while loading networks
The network list is now synced if no config is found to prevent races where the networks were not found
```