### PR TITLE
Freshen OWNERS with crio folks

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,8 +2,12 @@ assignees:
   - rajatchopra
   - sameo
   - dcbw
+  - haircommander
+  - saschagrunert
 approvers:
   - rajatchopra
   - sameo
   - dcbw
   - mrunalp
+  - haircommander
+  - saschagrunert


### PR DESCRIPTION
This is to request that Sascha and Peter both be added as approvers and
assignees for ocicni.  They both hold key roles on the crio team and can
assist in the maintainence of this package.

Signed-off-by: Brent Baude <bbaude@redhat.com>