### PR TITLE
ocicni: pass a Pod UID down to CNI plugins as K8S_POD_UID

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -795,6 +795,7 @@ func buildCNIRuntimeConf(podNetwork *PodNetwork, ifName string, runtimeConfig Ru
 			{"K8S_POD_NAMESPACE", podNetwork.Namespace},
 			{"K8S_POD_NAME", podNetwork.Name},
 			{"K8S_POD_INFRA_CONTAINER_ID", podNetwork.ID},
+			{"K8S_POD_UID", podNetwork.UID},
 		},
 		CapabilityArgs: map[string]interface{}{},
 	}

--- a/pkg/ocicni/ocicni_test.go
+++ b/pkg/ocicni/ocicni_test.go
@@ -381,8 +381,8 @@ var _ = Describe("ocicni operations", func() {
 		runtimeConfig = RuntimeConfig{IP: "172.16.0.1"}
 		rt, err = buildCNIRuntimeConf(podNetwork, ifName, runtimeConfig)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(len(rt.Args)).To(Equal(5))
-		Expect(rt.Args[4][1]).To(Equal("172.16.0.1"))
+		Expect(len(rt.Args)).To(Equal(6))
+		Expect(rt.Args[5][1]).To(Equal("172.16.0.1"))
 
 		// runtimeConfig with invalid MAC
 		runtimeConfig = RuntimeConfig{MAC: "f0:a6"}
@@ -393,16 +393,16 @@ var _ = Describe("ocicni operations", func() {
 		runtimeConfig = RuntimeConfig{MAC: "9e:0c:d9:b2:f0:a6"}
 		rt, err = buildCNIRuntimeConf(podNetwork, ifName, runtimeConfig)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(len(rt.Args)).To(Equal(5))
-		Expect(rt.Args[4][1]).To(Equal("9e:0c:d9:b2:f0:a6"))
+		Expect(len(rt.Args)).To(Equal(6))
+		Expect(rt.Args[5][1]).To(Equal("9e:0c:d9:b2:f0:a6"))
 
 		// runtimeConfig with valid IP and valid MAC
 		runtimeConfig = RuntimeConfig{IP: "172.16.0.1", MAC: "9e:0c:d9:b2:f0:a6"}
 		rt, err = buildCNIRuntimeConf(podNetwork, ifName, runtimeConfig)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(len(rt.Args)).To(Equal(6))
-		Expect(rt.Args[4][1]).To(Equal("172.16.0.1"))
-		Expect(rt.Args[5][1]).To(Equal("9e:0c:d9:b2:f0:a6"))
+		Expect(len(rt.Args)).To(Equal(7))
+		Expect(rt.Args[5][1]).To(Equal("172.16.0.1"))
+		Expect(rt.Args[6][1]).To(Equal("9e:0c:d9:b2:f0:a6"))
 
 		// runtimeConfig with portMappings is nil
 		runtimeConfig = RuntimeConfig{PortMappings: nil}
@@ -499,6 +499,7 @@ var _ = Describe("ocicni operations", func() {
 			Name:      "pod1",
 			Namespace: "namespace1",
 			ID:        "1234567890",
+			UID:       "9414bd03-b3d3-453e-9d9f-47dcee07958c",
 			NetNS:     networkNS.Path(),
 		}
 		results, err := ocicni.SetUpPod(podNet)
@@ -579,6 +580,7 @@ var _ = Describe("ocicni operations", func() {
 			Name:      "pod1",
 			Namespace: "namespace1",
 			ID:        "1234567890",
+			UID:       "9414bd03-b3d3-453e-9d9f-47dcee07958c",
 			NetNS:     networkNS.Path(),
 			Networks: []NetAttachment{
 				{Name: "network3"},
@@ -656,6 +658,7 @@ var _ = Describe("ocicni operations", func() {
 			Name:      "pod1",
 			Namespace: "namespace1",
 			ID:        "1234567890",
+			UID:       "9414bd03-b3d3-453e-9d9f-47dcee07958c",
 			NetNS:     networkNS.Path(),
 			Networks: []NetAttachment{
 				{Name: "network3"},
@@ -731,6 +734,7 @@ var _ = Describe("ocicni operations", func() {
 				Name:      "pod1",
 				Namespace: "namespace1",
 				ID:        containerID,
+				UID:       "9414bd03-b3d3-453e-9d9f-47dcee07958c",
 				NetNS:     networkNS.Path(),
 			}
 		})
@@ -797,6 +801,7 @@ var _ = Describe("ocicni operations", func() {
 			Name:      "pod1",
 			Namespace: "namespace1",
 			ID:        containerID,
+			UID:       "9414bd03-b3d3-453e-9d9f-47dcee07958c",
 			NetNS:     networkNS.Path(),
 			Networks: []NetAttachment{
 				{Name: netName1},

--- a/pkg/ocicni/types.go
+++ b/pkg/ocicni/types.go
@@ -71,12 +71,14 @@ type BandwidthConfig struct {
 
 // PodNetwork configures the network of a pod sandbox.
 type PodNetwork struct {
-	// Name is the name of the sandbox.
+	// Name is the name of the pod.
 	Name string
-	// Namespace is the namespace of the sandbox.
+	// Namespace is the namespace of the pod.
 	Namespace string
 	// ID is the id of the sandbox container.
 	ID string
+	// UID is the UID of the pod that owns the sandbox.
+	UID string
 	// NetNS is the network namespace path of the sandbox.
 	NetNS string
 


### PR DESCRIPTION
If a pod is deleted from the Kube API while a SetUpPod() call
is ongoing it would be nice if the CNI plugin could easily
figure that out and exit early. Plugins can watch the Kube API
for pod events, but there is a race where the pod could have
been deleted + recreated before the plugin is executed and
sets up the watches.

Since each new pod object will have a different UID, pass
the UID we get from the runtime down to the CNI plugins so
they can compare the UID they receive from ocicni with one
they read from the Kube API. If the two UIDs are different,
that means the pod was deleted + recreated before the plugin
ran, and the plugin may wish to exit early.

@trozet @mrunalp @mccv1r0 