### PR TITLE
[cni-0.x] Add option to disable the use of inotify

### DIFF
--- a/pkg/ocicni/ocicni_test.go
+++ b/pkg/ocicni/ocicni_test.go
@@ -211,7 +211,7 @@ var _ = Describe("ocicni operations", func() {
 		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "myplugin", "0.3.1")
 		Expect(err).NotTo(HaveOccurred())
 
-		ocicni, err := initCNI(&fakeExec{}, "", "test", tmpDir, "/opt/cni/bin")
+		ocicni, err := initCNI(&fakeExec{}, "", "test", tmpDir, false, "/opt/cni/bin")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ocicni.Status()).NotTo(HaveOccurred())
 
@@ -226,7 +226,7 @@ var _ = Describe("ocicni operations", func() {
 	})
 
 	It("finds an asynchronously written default network configuration", func() {
-		ocicni, err := initCNI(&fakeExec{}, "", "test", tmpDir, "/opt/cni/bin")
+		ocicni, err := initCNI(&fakeExec{}, "", "test", tmpDir, true, "/opt/cni/bin")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Writing a config that doesn't match the default network
@@ -248,7 +248,7 @@ var _ = Describe("ocicni operations", func() {
 	})
 
 	It("finds and refinds an asynchronously written default network configuration", func() {
-		ocicni, err := initCNI(&fakeExec{}, "", "test", tmpDir, "/opt/cni/bin")
+		ocicni, err := initCNI(&fakeExec{}, "", "test", tmpDir, true, "/opt/cni/bin")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Write the default network config
@@ -278,7 +278,7 @@ var _ = Describe("ocicni operations", func() {
 	})
 
 	It("finds an ASCIIbetically first network configuration as default real-time if given no default network name", func() {
-		ocicni, err := initCNI(&fakeExec{}, "", "", tmpDir, "/opt/cni/bin")
+		ocicni, err := initCNI(&fakeExec{}, "", "", tmpDir, true, "/opt/cni/bin")
 		Expect(err).NotTo(HaveOccurred())
 
 		_, _, err = writeConfig(tmpDir, "15-test.conf", "test", "myplugin", "0.3.1")
@@ -492,7 +492,7 @@ var _ = Describe("ocicni operations", func() {
 		}
 		fake.addPlugin(nil, conf, expectedResult, nil)
 
-		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, "/opt/cni/bin")
+		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, true, "/opt/cni/bin")
 		Expect(err).NotTo(HaveOccurred())
 
 		podNet := PodNetwork{
@@ -573,7 +573,7 @@ var _ = Describe("ocicni operations", func() {
 		}
 		fake.addPlugin(nil, conf2, expectedResult2, nil)
 
-		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, "/opt/cni/bin")
+		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, true, "/opt/cni/bin")
 		Expect(err).NotTo(HaveOccurred())
 
 		podNet := PodNetwork{
@@ -650,7 +650,7 @@ var _ = Describe("ocicni operations", func() {
 		}
 		fake.addPlugin(nil, conf2, expectedResult2, nil)
 
-		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, "/opt/cni/bin")
+		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, true, "/opt/cni/bin")
 		Expect(err).NotTo(HaveOccurred())
 
 		podNet := PodNetwork{
@@ -725,7 +725,7 @@ var _ = Describe("ocicni operations", func() {
 			fake.addPlugin([]string{fmt.Sprintf("CNI_IFNAME=%s", ifname1)}, conf1, nil, nil)
 			fake.addPlugin([]string{fmt.Sprintf("CNI_IFNAME=%s", ifname2)}, conf2, nil, nil)
 
-			ocicni, err = initCNI(fake, cacheDir, defaultNetName, tmpDir, "/opt/cni/bin")
+			ocicni, err = initCNI(fake, cacheDir, defaultNetName, tmpDir, true, "/opt/cni/bin")
 			Expect(err).NotTo(HaveOccurred())
 
 			podNet = PodNetwork{
@@ -790,7 +790,7 @@ var _ = Describe("ocicni operations", func() {
 		fake.addPlugin(nil, conf1, nil, nil)
 		fake.addPlugin(nil, conf2, nil, nil)
 
-		ocicni, err := initCNI(fake, cacheDir, defaultNetName, tmpDir, "/opt/cni/bin")
+		ocicni, err := initCNI(fake, cacheDir, defaultNetName, tmpDir, true, "/opt/cni/bin")
 		Expect(err).NotTo(HaveOccurred())
 		defer ocicni.Shutdown()
 


### PR DESCRIPTION
Cherry-pick #92 to the cni-0.x branch.

Add a new InitCNINoInotify function to allow the use of OCICNI without
the use of inotify.

For some workloads it is not required to watch the cni config directory.
With podman v3.2 we started using OCICNI for rootless users as well.
However the use of inotify is restricted by sysctl values
(fs.inotify.max_user_instances and fs.inotify.max_user_watches).
By default only 128 processes can use inotify.

Since this limit is easy to reach and inotify is not required for our
use case it would be great to have this option to disable it.

see containers/podman#10686
```release-note
Add new InitCNINoInotify function to disable the use of inotify.
```