### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "release-note-none"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
We're now enabling dependabot for this repo to stay up to date dependency wise.