### PR TITLE
Remove code that sets lo to down prior ns deletion

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -658,11 +658,6 @@ func (plugin *cniNetworkPlugin) TearDownPodWithContext(ctx context.Context, podN
 	plugin.podLock(podNetwork).Lock()
 	defer plugin.podUnlock(podNetwork)
 
-	if err := tearDownLoopback(podNetwork.NetNS); err != nil {
-		// ignore error
-		logrus.Warningf("Ignoring error tearing down loopback interface: %v", err)
-	}
-
 	return plugin.forEachNetwork(&podNetwork, true, func(network *cniNetwork, podNetwork *PodNetwork, rt *libcni.RuntimeConf) error {
 		fullPodName := buildFullPodName(*podNetwork)
 		logrus.Infof("Deleting pod %s from CNI network %q (type=%v)", fullPodName, network.name, network.config.Plugins[0].Network.Type)

--- a/pkg/ocicni/util_linux.go
+++ b/pkg/ocicni/util_linux.go
@@ -74,20 +74,6 @@ func getContainerDetails(nsm *nsManager, netnsPath, interfaceName, addrType stri
 	return ipNet, &mac, nil
 }
 
-func tearDownLoopback(netns string) error {
-	return ns.WithNetNSPath(netns, func(_ ns.NetNS) error {
-		link, err := netlink.LinkByName(loIfname)
-		if err != nil {
-			return err // not tested
-		}
-		err = netlink.LinkSetDown(link)
-		if err != nil {
-			return err // not tested
-		}
-		return nil
-	})
-}
-
 func bringUpLoopback(netns string) error {
 	if err := ns.WithNetNSPath(netns, func(_ ns.NetNS) error {
 		link, err := netlink.LinkByName(loIfname)


### PR DESCRIPTION
I am not sure this code is needed since deleting the network namespace takes care of lo. If this was done for a specific reason I am curious to hear about it :-) It looks like it was an attempt to duplicate the behavior of the loopback plugin. 

I can apply a deprecation flag to tearDownLoopback func if that is preferred

Signed-off-by: Michael Zappa <Michael.Zappa@stateless.net>