### PR TITLE
ocicni: fix checkNetwork() to use the right Result version for uncached results

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -773,7 +773,7 @@ func (network *cniNetwork) checkNetwork(ctx context.Context, rt *libcni.RuntimeC
 	}
 
 	result = &cniv1.Result{
-		CNIVersion: network.config.CNIVersion,
+		CNIVersion: cniv1.ImplementedSpecVersion,
 		Interfaces: []*cniv1.Interface{cniInterface},
 		IPs:        ips,
 	}


### PR DESCRIPTION
The cniVersion of the result must be compatible with the Go struct
that implements it. In this case, the incoming config is 0.3.1 but
the network has no cached result, so checkNetwork() creates a
1.0.0 Result type but mistakenly sets the result's internal version
string to the incoming config version (0.3.1).

libcni's internal Convert() function looks up converters based on
the internal Result version string, in this case 0.3.1. That
ends up calling the 1.0.0's convertFrom04x() which, of course,
expects the incoming result object to be a 040 Go Result struct,
but because checkNetwork() created a 100 Go Result struct,
it clearly isn't, and the type assertion fails and it panics.

Fixes: https://github.com/cri-o/cri-o/issues/5889

```
May 17 11:45:59 node1 crio[26471]: time="2022-05-17 11:45:59.130078469+08:00" level=info msg="Checking CNI network multus-cni-network (config version=0.3.1) nsManager=&{/usr/bin/nsenter}"
May 17 11:45:59 node1 crio[26471]: panic: interface conversion: types.Result is *types100.Result, not *types040.Result
May 17 11:45:59 node1 crio[26471]: goroutine 1 [running]:
May 17 11:45:59 node1 crio[26471]: panic({0x1d69d60, 0xc000480630})
May 17 11:45:59 node1 crio[26471]:         /usr/lib/go-1.18/src/runtime/panic.go:941 +0x397 fp=0xc0008f6640 sp=0xc0008f6580 pc=0x441137
May 17 11:45:59 node1 crio[26471]: runtime.panicdottypeE(...)
May 17 11:45:59 node1 crio[26471]:         /usr/lib/go-1.18/src/runtime/iface.go:262
May 17 11:45:59 node1 crio[26471]: runtime.panicdottypeI(0x0?, 0x1dbf180, 0x1dac900)
May 17 11:45:59 node1 crio[26471]:         /usr/lib/go-1.18/src/runtime/iface.go:272 +0x7c fp=0xc0008f6668 sp=0xc0008f6640 pc=0x41649c
May 17 11:45:59 node1 crio[26471]: github.com/cri-o/cri-o/vendor/github.com/containernetworking/cni/pkg/types/100.convertFrom04x({0x238ab10?, 0xc000445e40?}, {0x200e65a?, 0xc0006683f0?})
May 17 11:45:59 node1 crio[26471]:         /usr/src/packages/BUILD/src/github.com/cri-o/cri-o/vendor/github.com/containernetworking/cni/pkg/types/100/types.go:126 +0x9c5 fp=0xc0008f67b8 sp=0xc0008f6668 pc=0xf92745
May 17 11:45:59 node1 crio[26471]: github.com/cri-o/cri-o/vendor/github.com/containernetworking/cni/pkg/types/internal.Convert({0x238ab10, 0xc000445e40}, {0x200e65a, 0x5})
May 17 11:45:59 node1 crio[26471]:         /usr/src/packages/BUILD/src/github.com/cri-o/cri-o/vendor/github.com/containernetworking/cni/pkg/types/internal/convert.go:73 +0x1a5 fp=0xc0008f6868 sp=0xc0008f67b8 pc=0xf8b825
May 17 11:45:59 node1 crio[26471]: github.com/cri-o/cri-o/vendor/github.com/containernetworking/cni/pkg/types/100.(*Result).GetAsVersion(0xc000481650?, {0x200e65a?, 0xc0003e4c00?})
May 17 11:45:59 node1 crio[26471]:         /usr/src/packages/BUILD/src/github.com/cri-o/cri-o/vendor/github.com/containernetworking/cni/pkg/types/100/types.go:211 +0x65 fp=0xc0008f6898 sp=0xc0008f6868 pc=0xf93385
May 17 11:45:59 node1 crio[26471]: github.com/cri-o/cri-o/vendor/github.com/containernetworking/cni/pkg/types/100.GetResult({0x238ab10?, 0xc000445e40?})
May 17 11:45:59 node1 crio[26471]:         /usr/src/packages/BUILD/src/github.com/cri-o/cri-o/vendor/github.com/containernetworking/cni/pkg/types/100/types.go:65 +0x37 fp=0xc0008f68d0 sp=0xc0008f6898 pc=0xf91c37
May 17 11:45:59 node1 crio[26471]: github.com/cri-o/cri-o/server.(*Server).getSandboxIPs(0xc000246e00, 0xc000842000)
May 17 11:45:59 node1 crio[26471]:         /usr/src/packages/BUILD/src/github.com/cri-o/cri-o/server/sandbox_network.go:146 +0x178 fp=0xc0008f6b00 sp=0xc0008f68d0 pc=0x1b51058
May 17 11:45:59 node1 crio[26471]: github.com/cri-o/cri-o/server.(*Server).restore(0xc000246e00, {0x238a480?, 0xc0003c4840})
May 17 11:45:59 node1 crio[26471]:         /usr/src/packages/BUILD/src/github.com/cri-o/cri-o/server/server.go:280 +0xe6d fp=0xc0008f7558 sp=0xc0008f6b00 pc=0x1b64e0d
May 17 11:45:59 node1 crio[26471]: github.com/cri-o/cri-o/server.New({0x238a480?, 0xc0003c4840}, {0x23723f8, 0xc0004fa000})
May 17 11:45:59 node1 crio[26471]:         /usr/src/packages/BUILD/src/github.com/cri-o/cri-o/server/server.go:442 +0x598 fp=0xc0008f77f8 sp=0xc0008f7558 pc=0x1b66278
```

Signed-off-by: Dan Williams <dcbw@redhat.com>
```release-note
fix a panic caused by using the improper Result structure version
```