### PR TITLE
add cgroupPath capability arg

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -858,6 +858,12 @@ func buildCNIRuntimeConf(podNetwork *PodNetwork, ifName string, runtimeConfig Ru
 	if len(podNetwork.Aliases) > 0 {
 		rt.CapabilityArgs["aliases"] = podNetwork.Aliases
 	}
+
+	// set cgroupPath in Capabilities
+	if runtimeConfig.CgroupPath != "" {
+		rt.CapabilityArgs["cgroupPath"] = runtimeConfig.CgroupPath
+	}
+
 	return rt, nil
 }
 

--- a/pkg/ocicni/ocicni_test.go
+++ b/pkg/ocicni/ocicni_test.go
@@ -512,6 +512,13 @@ var _ = Describe("ocicni operations", func() {
 		Expect(len(ir)).To(Equal(1))
 		Expect(len(ir[0])).To(Equal(1))
 		Expect(ir[0][0].Gateway).To(Equal("192.168.0.254"))
+
+		runtimeConfig = RuntimeConfig{CgroupPath: "/slice/pod/testing"}
+		rt, err = buildCNIRuntimeConf(podNetwork, ifName, runtimeConfig)
+		Expect(err).NotTo(HaveOccurred())
+		cg, ok := rt.CapabilityArgs["cgroupPath"].(string)
+		Expect(ok).To(Equal(true))
+		Expect(cg).To(Equal("/slice/pod/testing"))
 	})
 
 	It("sets up and tears down a pod using the default network", func() {

--- a/pkg/ocicni/types.go
+++ b/pkg/ocicni/types.go
@@ -55,6 +55,9 @@ type RuntimeConfig struct {
 	Bandwidth *BandwidthConfig
 	// IpRanges is the ip range gather which is used for address allocation
 	IpRanges [][]IpRange
+	// CgroupPath is the path to the pod's cgroup
+	// e.g. "/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-pod28ce45bc_63f8_48a3_a99b_cfb9e63c856c.slice"
+	CgroupPath string
 }
 
 // BandwidthConfig maps to the standard CNI bandwidth Capability


### PR DESCRIPTION
Add in the plumbing for the cgroupPath capability.

There is a similar PR implementing support in go-cni: https://github.com/containerd/go-cni/pull/110