### PR TITLE
pkg/ocicni: Use 'ifconfig -j' to access jail network state

### DIFF
--- a/hack/find-godeps.sh
+++ b/hack/find-godeps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # $1 - base path of the source tree
 # $2 - subpath under $1 to find *.go dependencies for


### PR DESCRIPTION
The use of 'jexec' for this requires a compatible ifconfig binary inside the jail which owns the network state and using 'ifconfig -j' lets us merge the jail which owns the pod network with the infra container.

This also fixes some parsing bugs in getContainerDetails which were not noticed before since most of the time we get the information from cni's CheckNetworkList.
