### PR TITLE
add support for cni STATUS verb

### DIFF
--- a/pkg/ocicni/types.go
+++ b/pkg/ocicni/types.go
@@ -125,6 +125,8 @@ type NetResult struct {
 }
 
 // CNIPlugin is the interface that needs to be implemented by a plugin.
+//
+//nolint:interfacebloat // existing API
 type CNIPlugin interface {
 	// Name returns the plugin's name. This will be used when searching
 	// for a plugin by name, e.g.
@@ -156,6 +158,8 @@ type CNIPlugin interface {
 
 	// NetworkStatus returns error if the network plugin is in error state
 	Status() error
+
+	StatusWithContext(ctx context.Context) error
 
 	// Shutdown terminates all driver operations
 	Shutdown() error


### PR DESCRIPTION
The new CNI v1.1 STATUS verb allows for plugins to report that they are not ready to handle ADDs. It is a cleaner API than the awkward "remove-config-file" dance currently in use.

The libcni code gracefully handles older versions, so this is backwards compatible.

/kind feature

```release-note
For plugins that support CNI v1.1, ocicni now uses the STATUS verb to determine if the network is ready for ADD requests.
```
