### PR TITLE
add CNI GC support

### DIFF
--- a/pkg/ocicni/types.go
+++ b/pkg/ocicni/types.go
@@ -156,6 +156,9 @@ type CNIPlugin interface {
 	// GetPodNetworkStatusWithContext is the same as GetPodNetworkStatus but takes a context
 	GetPodNetworkStatusWithContext(ctx context.Context, network PodNetwork) ([]NetResult, error)
 
+	// GC cleans up any resources concerned with stale pods
+	GC(ctx context.Context, validPods []*PodNetwork) error
+
 	// NetworkStatus returns error if the network plugin is in error state
 	Status() error
 


### PR DESCRIPTION
/kind feature

This adds CNI GC support. GC is a CNI verb that allows runtimes (i.e. cri-o) to specify a list of known-good attachments, allowing network plugins to clean up stale resources. This permits cleanup of, for example, leaked IPAM allocations.

This does require rethinking the locking approach slightly, as GC cannot be executed in paralle with other pod operations.

```release-note
Add CNI GC support, which allows network plugins to clean up stale resources.
```
