### PR TITLE
Reduce useless log messages about default CNI network

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -379,7 +379,9 @@ func (plugin *cniNetworkPlugin) syncNetworkConfig(ctx context.Context) error {
 	// Update defaultNetName if it is changeable
 	if plugin.defaultNetName.changeable {
 		plugin.defaultNetName.name = defaultNetName
-		logrus.Infof("Updated default CNI network name to %s", defaultNetName)
+		if defaultNetName != "" {
+			logrus.Infof("Updated default CNI network name to %s", defaultNetName)
+		}
 	} else {
 		logrus.Debugf("Default CNI network name %s is unchangeable", plugin.defaultNetName.name)
 	}


### PR DESCRIPTION
The logs with empty default CNI network updates are useless and produce much noise. 

```
time="2024-06-25 19:33:12.783576005Z" level=info msg="Updated default CNI network name to "
time="2024-06-25 19:33:12.783958197Z" level=info msg="Updated default CNI network name to "
time="2024-06-25 19:33:12.784004164Z" level=info msg="Updated default CNI network name to "
time="2024-06-25 19:33:12.784321809Z" level=info msg="Updated default CNI network name to "
time="2024-06-25 19:33:12.784364691Z" level=info msg="Updated default CNI network name to "
```

This PR change log, so only actual changes are logged.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Reduce useless log messages.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Reduce useless log messages about default CNI network changes
```
