### PR TITLE
Bump required go to 1.23

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,10 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-   interval: daily
+    interval: daily
   open-pull-requests-limit: 10
   labels:
-   - "release-note-none"
+     - "release-note-none"
   groups:
     actions:
       update-types:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/cri-o/ocicni
 
-go 1.22
-toolchain go1.23.2
+go 1.23
 
 require (
 	github.com/containernetworking/cni v1.2.3


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Remove the toolchain restriction and just force use go 1.23 because of the dependencies.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
