### PR TITLE
Log events only related to a valid CNI configuration file.

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -155,10 +156,13 @@ func (plugin *cniNetworkPlugin) monitorConfDir(ctx context.Context, start *sync.
 	start.Done()
 	plugin.done.Add(1)
 	defer plugin.done.Done()
+	exts := []string{".conf", ".conflist", ".json"}
 	for {
 		select {
 		case event := <-plugin.watcher.Events:
-			logrus.Infof("CNI monitoring event %v", event)
+			if slices.Contains(exts, filepath.Ext(event.Name)) {
+				logrus.Infof("CNI monitoring event %v", event)
+			}
 
 			var defaultDeleted bool
 			createWriteRename := event.Op&fsnotify.Create == fsnotify.Create ||


### PR DESCRIPTION
Logs only `.conf`, `.json` and `.conflist` files.

Context https://github.com/cri-o/ocicni/pull/208#issuecomment-2213233802

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

#### What this PR does / why we need it:

Reduce noisy log messages

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:

[Some additional context is here.](https://github.com/cri-o/ocicni/pull/208)

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Log events only related to a valid CNI configuration file.
```


@kwilczynski @saschagrunert PTAL