### PR TITLE
Switch to go 1.24

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,6 @@
 ---
 name: test
-
 on: ["push", "pull_request"]
-
-env:
-  GO_VERSION: "1.23"
-
 jobs:
   build:
     name: Build / ${{ matrix.arch }}
@@ -23,7 +18,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: Build on ${{ matrix.arch }}
         run: make GOARCH=${{ matrix.arch }}
 
@@ -34,7 +29,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install test binaries
         run: |
@@ -59,5 +54,5 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,7 +86,6 @@ linters:
     - staticcheck
     - stylecheck
     - tagalign
-    - tenv
     - testableexamples
     - testifylint
     - thelper

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ BUILD_INFO := $(shell date +%s)
 
 BUILD_PATH := $(shell pwd)/build
 GOLANGCI_LINT := ${BUILD_PATH}/golangci-lint
-GOLANGCI_LINT_VERSION := v1.63.4
+GOLANGCI_LINT_VERSION := v1.64.8
 
 # If GOPATH not specified, use one in the local directory
 ifeq ($(GOPATH),)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/cri-o/ocicni
 
-go 1.23
+go 1.24
+
 require (
 	github.com/containernetworking/cni v1.2.3
 	github.com/containernetworking/plugins v1.6.2


### PR DESCRIPTION

#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
Switch to the most recent golang version to allow blocked dependency upgrades.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
@cri-o/cri-o-maintainers PTAL
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
