### PR TITLE
Don't run CI twice for branched PR's

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,13 @@
 ---
 name: test
-on: ["push", "pull_request"]
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
 jobs:
   build:
     name: Build / ${{ matrix.arch }}


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
PR's from branches should not run twice, like for the dependabot upgrades.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
PTAL @cri-o/cri-o-maintainers 
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
