### PR TITLE
Fix possible runtime panic if network plugins are empty

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -782,7 +782,13 @@ func (plugin *cniNetworkPlugin) TearDownPodWithContext(ctx context.Context, podN
 
 	return plugin.forEachNetwork(ctx, &podNetwork, true, func(network *cniNetwork, podNetwork *PodNetwork, rt *libcni.RuntimeConf) error {
 		fullPodName := buildFullPodName(podNetwork)
-		logrus.Infof("Deleting pod %s from CNI network %q (type=%v)", fullPodName, network.name, network.config.Plugins[0].Network.Type)
+
+		networkType := "unknown"
+		if network.config != nil && len(network.config.Plugins) > 0 && network.config.Plugins[0].Network != nil {
+			networkType = network.config.Plugins[0].Network.Type
+		}
+
+		logrus.Infof("Deleting pod %s from CNI network %q (type=%v)", fullPodName, network.name, networkType)
 
 		if err := network.deleteFromNetwork(ctx, rt, plugin.cniConfig); err != nil {
 			return fmt.Errorf("error removing pod %s from CNI network %q: %w", fullPodName, network.name, err)

--- a/pkg/ocicni/types.go
+++ b/pkg/ocicni/types.go
@@ -28,8 +28,6 @@ type PortMapping struct {
 
 // IpRange maps to the standard CNI ipRanges Capability
 // see: https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md
-//
-//nolint:stylecheck // already define API
 type IpRange struct {
 	// Subnet is the whole CIDR
 	Subnet string `json:"subnet"`
@@ -56,7 +54,6 @@ type RuntimeConfig struct {
 	// Bandwidth is the bandwidth limiting of the pod
 	Bandwidth *BandwidthConfig
 	// IpRanges is the ip range gather which is used for address allocation
-	//nolint:stylecheck // already define API
 	IpRanges [][]IpRange
 	// CgroupPath is the path to the pod's cgroup
 	// e.g. "/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-pod28ce45bc_63f8_48a3_a99b_cfb9e63c856c.slice"


### PR DESCRIPTION

<!--  Thanks for sending a pull request!


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Falling back to an 'unknown' type if the pre-conditions could lead into a runtime panic.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed possible runtime panic if network plugins are empty.
```
