### PR TITLE
Update golangci-lint to v2.11.4 and enable new linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
 linters:
   default: none
   enable:
+    - arangolint
     - asasalint
     - asciicheck
     - bidichk
@@ -12,11 +13,13 @@ linters:
     - containedctx
     - contextcheck
     - copyloopvar
+    - cyclop
     - decorder
     - dogsled
     - dupl
     - dupword
     - durationcheck
+    - embeddedstructfieldcheck
     - errcheck
     - errchkjson
     - errname
@@ -26,14 +29,18 @@ linters:
     - fatcontext
     - forbidigo
     - forcetypeassert
+    - funcorder
+    - funlen
     - ginkgolinter
     - gocheckcompilerdirectives
     - gochecknoglobals
     - gochecknoinits
     - gochecksumtype
+    - gocognit
     - goconst
     - gocritic
     - gocyclo
+    - godoclint
     - godot
     - godox
     - goheader
@@ -46,14 +53,18 @@ linters:
     - iface
     - importas
     - inamedparam
+    - ireturn
     - ineffassign
     - interfacebloat
     - intrange
+    - iotamixing
     - loggercheck
     - maintidx
     - makezero
     - mirror
     - misspell
+    - mnd
+    - modernize
     - musttag
     - nakedret
     - nestif
@@ -79,37 +90,54 @@ linters:
     - sqlclosecheck
     - staticcheck
     - tagalign
+    - tagliatelle
     - testableexamples
     - testifylint
     - thelper
     - tparallel
     - unconvert
     - unparam
+    - unqueryvet
     - unused
     - usestdlibvars
     - usetesting
     - wastedassign
     - whitespace
-    - wsl
+    - wsl_v5
     - zerologlint
-    # - cyclop
     # - depguard
     # - err113
     # - exhaustruct
-    # - funlen
-    # - gocognit
     # - gosec
-    # - ireturn
     # - lll
-    # - mnd
+    # - noinlineerr
     # - nonamedreturns
-    # - tagliatelle
     # - testpackage
     # - varnamelen
     # - wrapcheck
   settings:
+    cyclop:
+      max-complexity: 15
+    funcorder:
+      struct-method: false
+    funlen:
+      lines: 85
+      statements: 50
+    gocognit:
+      min-complexity: 35
     gocritic:
       enable-all: true
+    ireturn:
+      allow:
+        - error
+        - stdlib
+        - github.com/cri-o/ocicni/pkg/ocicni.CNIPlugin
+        - github.com/containernetworking/cni/pkg/types.Result
+    mnd:
+      ignored-numbers:
+        - "0o755"
+      ignored-functions:
+        - "strings.SplitN"
     nestif:
       min-complexity: 11
     revive:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ BUILD_INFO := $(shell date +%s)
 
 BUILD_PATH := $(shell pwd)/build
 GOLANGCI_LINT := ${BUILD_PATH}/golangci-lint
-GOLANGCI_LINT_VERSION := v2.0.1
+GOLANGCI_LINT_VERSION := v2.11.4
 
 # If GOPATH not specified, use one in the local directory
 ifeq ($(GOPATH),)

--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -24,9 +24,9 @@ import (
 )
 
 type cniNetworkPlugin struct {
-	cniConfig *libcni.CNIConfig
-
 	sync.RWMutex
+
+	cniConfig      *libcni.CNIConfig
 	defaultNetName netName
 	networks       map[string]*cniNetwork
 
@@ -295,6 +295,7 @@ func initCNI(exec cniinvoke.Exec, cacheDir, defaultNetName, confDir string, useI
 		startWg.Add(1)
 
 		go plugin.monitorConfDir(ctx, &startWg)
+
 		startWg.Wait()
 	}
 
@@ -402,9 +403,9 @@ func loadNetworks(ctx context.Context, confDir string, cni *libcni.CNIConfig) (n
 	return networks, defaultNetName, nil
 }
 
-const (
-	loIfname string = "lo"
-)
+const loIfname string = "lo"
+
+const keyValuePairLen = 2
 
 func (plugin *cniNetworkPlugin) syncNetworkConfig(ctx context.Context) error {
 	networks, defaultNetName, err := loadNetworks(ctx, plugin.confDir, plugin.cniConfig)
@@ -531,6 +532,7 @@ func (plugin *cniNetworkPlugin) fillPodNetworks(podNetwork *PodNetwork) error {
 			allIfNames[net.Ifname] = true
 		}
 	}
+
 netLoop:
 	for i, network := range podNetwork.Networks {
 		if network.Ifname == "" {
@@ -655,10 +657,12 @@ func (plugin *cniNetworkPlugin) SetUpPodWithContext(ctx context.Context, podNetw
 	if err := plugin.forEachNetwork(ctx, &podNetwork, false, func(network *cniNetwork, podNetwork *PodNetwork, rt *libcni.RuntimeConf) error {
 		fullPodName := buildFullPodName(podNetwork)
 		logrus.Infof("Adding pod %s to CNI network %q (type=%v)", fullPodName, network.name, network.config.Plugins[0].Network.Type)
+
 		result, err := network.addToNetwork(ctx, rt, plugin.cniConfig)
 		if err != nil {
 			return fmt.Errorf("error adding pod %s to CNI network %q: %w", fullPodName, network.name, err)
 		}
+
 		results = append(results, NetResult{
 			Result: result,
 			NetAttachment: NetAttachment{
@@ -717,7 +721,7 @@ func (plugin *cniNetworkPlugin) getCachedNetworkInfo(containerID string) ([]NetA
 		cachedInfo := struct {
 			Kind        string `json:"kind"`
 			IfName      string `json:"ifName"`
-			ContainerID string `json:"containerID"`
+			ContainerID string `json:"containerID"` //nolint:tagliatelle // CNI cache format
 			NetName     string `json:"networkName"`
 		}{}
 
@@ -828,10 +832,12 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatusWithContext(ctx context.Conte
 	if err := plugin.forEachNetwork(ctx, &podNetwork, true, func(network *cniNetwork, podNetwork *PodNetwork, rt *libcni.RuntimeConf) error {
 		fullPodName := buildFullPodName(podNetwork)
 		logrus.Infof("Checking pod %s for CNI network %s (type=%v)", fullPodName, network.name, network.config.Plugins[0].Network.Type)
+
 		result, err := network.checkNetwork(ctx, rt, plugin.cniConfig, plugin.nsManager, podNetwork.NetNS)
 		if err != nil {
 			return fmt.Errorf("error checking pod %s for CNI network %q: %w", fullPodName, network.name, err)
 		}
+
 		if result != nil {
 			results = append(results, NetResult{
 				Result: result,
@@ -937,7 +943,7 @@ func (network *cniNetwork) checkNetwork(ctx context.Context, rt *libcni.RuntimeC
 	errs := []error{}
 
 	for _, version := range []string{"4", "6"} {
-		ip, mac, err := getContainerDetails(nsManager, netns, rt.IfName, "-"+version)
+		ip, mac, err := getContainerDetails(ctx, nsManager, netns, rt.IfName, "-"+version)
 		if err == nil {
 			if cniInterface == nil {
 				cniInterface = &cniv1.Interface{
@@ -1010,7 +1016,7 @@ func buildCNIRuntimeConf(podNetwork *PodNetwork, ifName string, runtimeConfig *R
 
 	// Propagate existing CNI_ARGS to non-k8s consumers
 	for kvpairs := range strings.SplitSeq(os.Getenv("CNI_ARGS"), ";") {
-		if keyval := strings.SplitN(kvpairs, "=", 2); len(keyval) == 2 {
+		if keyval := strings.SplitN(kvpairs, "=", keyValuePairLen); len(keyval) == keyValuePairLen {
 			rt.Args = append(rt.Args, [2]string{keyval[0], keyval[1]})
 		}
 	}

--- a/pkg/ocicni/ocicni_test.go
+++ b/pkg/ocicni/ocicni_test.go
@@ -81,7 +81,7 @@ type TestConf struct {
 	Name       string `json:"name,omitempty"`
 	Type       string `json:"type,omitempty"`
 
-	ValidAttachments []types.GCAttachment `json:"cni.dev/valid-attachments,omitempty"`
+	ValidAttachments []types.GCAttachment `json:"cni.dev/valid-attachments,omitempty"` //nolint:tagliatelle // CNI spec format
 }
 
 func (f *fakeExec) addPlugin(expectedEnv []string, expectedConf string, result types.Result) {
@@ -221,6 +221,7 @@ var _ = Describe("ocicni operations", func() {
 
 	BeforeEach(func() {
 		var err error
+
 		tmpDir, err = os.MkdirTemp("", "ocicni_tmp")
 		Expect(err).NotTo(HaveOccurred())
 		tmpBinDir, err = os.MkdirTemp("", "ocicni_tmp_bin")
@@ -259,6 +260,7 @@ var _ = Describe("ocicni operations", func() {
 		// Ensure the default network is the one we expect
 		tmp, ok := ocicni.(*cniNetworkPlugin)
 		Expect(ok).To(BeTrue())
+
 		net := tmp.getDefaultNetwork()
 		Expect(net.name).To(Equal("test"))
 		Expect(net.config.Plugins).ToNot(BeEmpty())
@@ -282,6 +284,7 @@ var _ = Describe("ocicni operations", func() {
 
 		tmp, ok := ocicni.(*cniNetworkPlugin)
 		Expect(ok).To(BeTrue())
+
 		net := tmp.getDefaultNetwork()
 		Expect(net.name).To(Equal("test"))
 		Expect(net.config.Plugins).ToNot(BeEmpty())
@@ -311,12 +314,15 @@ var _ = Describe("ocicni operations", func() {
 			if net == nil {
 				return errors.New("no default net")
 			}
+
 			if net.name != "test" {
 				return errors.New("name not test")
 			}
+
 			if len(net.config.Plugins) == 0 {
 				return errors.New("no plugins")
 			}
+
 			if net.config.Plugins[0].Network.Type != "myplugin" {
 				return errors.New("wrong plugin type")
 			}
@@ -341,6 +347,7 @@ var _ = Describe("ocicni operations", func() {
 		// Ensure the default network is the one we expect
 		tmp, ok := ocicni.(*cniNetworkPlugin)
 		Expect(ok).To(BeTrue())
+
 		net := tmp.getDefaultNetwork()
 		Expect(net.name).To(Equal("test"))
 		Expect(net.config.Plugins).ToNot(BeEmpty())
@@ -374,6 +381,7 @@ var _ = Describe("ocicni operations", func() {
 		// Ensure the default network is the one we expect
 		tmp, ok := ocicni.(*cniNetworkPlugin)
 		Expect(ok).To(BeTrue())
+
 		net := tmp.getDefaultNetwork()
 		Expect(net.name).To(Equal("test"))
 		Expect(net.config.Plugins).ToNot(BeEmpty())
@@ -408,6 +416,7 @@ var _ = Describe("ocicni operations", func() {
 
 		tmp, ok := ocicni.(*cniNetworkPlugin)
 		Expect(ok).To(BeTrue())
+
 		net := tmp.getDefaultNetwork()
 		Expect(net.name).To(Equal("test"))
 		Expect(net.config.Plugins).ToNot(BeEmpty())
@@ -449,6 +458,7 @@ var _ = Describe("ocicni operations", func() {
 
 		tmp, ok := ocicni.(*cniNetworkPlugin)
 		Expect(ok).To(BeTrue())
+
 		net := tmp.getDefaultNetwork()
 		Expect(net.name).To(Equal("test"))
 		Expect(net.config.Plugins).ToNot(BeEmpty())
@@ -578,6 +588,7 @@ var _ = Describe("ocicni operations", func() {
 		}}}
 		rt, err = buildCNIRuntimeConf(podNetwork, ifName, runtimeConfig)
 		Expect(err).NotTo(HaveOccurred())
+
 		pm, ok := rt.CapabilityArgs["portMappings"].([]PortMapping)
 		Expect(ok).To(BeTrue())
 		Expect(pm).To(HaveLen(1))
@@ -600,6 +611,7 @@ var _ = Describe("ocicni operations", func() {
 		}}
 		rt, err = buildCNIRuntimeConf(podNetwork, ifName, runtimeConfig)
 		Expect(err).NotTo(HaveOccurred())
+
 		bw, ok := rt.CapabilityArgs["bandwidth"].(map[string]uint64)
 		Expect(ok).To(BeTrue())
 		Expect(bw["ingressRate"]).To(Equal(uint64(1)))
@@ -621,6 +633,7 @@ var _ = Describe("ocicni operations", func() {
 		}}}}
 		rt, err = buildCNIRuntimeConf(podNetwork, ifName, runtimeConfig)
 		Expect(err).NotTo(HaveOccurred())
+
 		ir, ok := rt.CapabilityArgs["ipRanges"].([][]IpRange)
 		Expect(ok).To(BeTrue())
 		Expect(ir).To(HaveLen(1))
@@ -630,6 +643,7 @@ var _ = Describe("ocicni operations", func() {
 		runtimeConfig = &RuntimeConfig{CgroupPath: "/slice/pod/testing"}
 		rt, err = buildCNIRuntimeConf(podNetwork, ifName, runtimeConfig)
 		Expect(err).NotTo(HaveOccurred())
+
 		cg, ok := rt.CapabilityArgs["cgroupPath"].(string)
 		Expect(ok).To(BeTrue())
 		Expect(cg).To(Equal("/slice/pod/testing"))
@@ -680,6 +694,7 @@ var _ = Describe("ocicni operations", func() {
 		// Make sure loopback device is up
 		err = networkNS.Do(func(_ ns.NetNS) error {
 			defer GinkgoRecover()
+
 			link, err := netlink.LinkByName("lo")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(link.Attrs().Flags & net.FlagUp).To(Equal(net.FlagUp))
@@ -940,6 +955,7 @@ var _ = Describe("ocicni operations", func() {
 			ifname2        string = "eth1"
 			defaultNetName string = "test"
 		)
+
 		var (
 			fake   *fakeExec
 			ocicni CNIPlugin
@@ -1039,6 +1055,7 @@ var _ = Describe("ocicni operations", func() {
 
 		ocicni, err := initCNI(fake, cacheDir, defaultNetName, tmpDir, true, "/opt/cni/bin")
 		Expect(err).NotTo(HaveOccurred())
+
 		defer Expect(ocicni.Shutdown()).NotTo(HaveOccurred())
 
 		podNet := PodNetwork{

--- a/pkg/ocicni/types.go
+++ b/pkg/ocicni/types.go
@@ -23,7 +23,7 @@ type PortMapping struct {
 	// Protocol is the protocol of the port mapping.
 	Protocol string `json:"protocol"`
 	// HostIP is the host ip to use.
-	HostIP string `json:"hostIP"`
+	HostIP string `json:"hostIP"` //nolint:tagliatelle // CNI spec format
 }
 
 // IpRange maps to the standard CNI ipRanges Capability
@@ -59,7 +59,7 @@ type RuntimeConfig struct {
 	// e.g. "/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-pod28ce45bc_63f8_48a3_a99b_cfb9e63c856c.slice"
 	CgroupPath string
 	// PodAnnotations are the annotations of the pod.
-	PodAnnotations *map[string]string `json:"io.kubernetes.cri.pod-annotations,omitempty"`
+	PodAnnotations *map[string]string `json:"io.kubernetes.cri.pod-annotations,omitempty"` //nolint:tagliatelle // Kubernetes API format
 }
 
 // BandwidthConfig maps to the standard CNI bandwidth Capability
@@ -114,11 +114,12 @@ type NetAttachment struct {
 
 // NetResult contains the result the network attachment operation.
 type NetResult struct {
-	// Result is the CNI Result
-	Result types.Result
 	// NetAttachment contains the network and interface names of this
 	// network attachment
 	NetAttachment
+
+	// Result is the CNI Result
+	Result types.Result
 }
 
 // CNIPlugin is the interface that needs to be implemented by a plugin.

--- a/pkg/ocicni/types_unix.go
+++ b/pkg/ocicni/types_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows && !freebsd
-// +build !windows,!freebsd
 
 package ocicni
 

--- a/pkg/ocicni/util_linux.go
+++ b/pkg/ocicni/util_linux.go
@@ -1,9 +1,9 @@
 //go:build linux
-// +build linux
 
 package ocicni
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -14,7 +14,12 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-const defaultNamespaceEnterCommandName = "nsenter"
+const (
+	defaultNamespaceEnterCommandName = "nsenter"
+	minIPAddrFields                  = 4
+	minLinkOutputLines               = 2
+	minLinkFields                    = 4
+)
 
 type nsManager struct {
 	nsenterPath string
@@ -22,14 +27,15 @@ type nsManager struct {
 
 func (nsm *nsManager) init() error {
 	var err error
+
 	nsm.nsenterPath, err = exec.LookPath(defaultNamespaceEnterCommandName)
 
 	return err
 }
 
-func getContainerDetails(nsm *nsManager, netnsPath, interfaceName, addrType string) (*net.IPNet, *net.HardwareAddr, error) {
+func getContainerDetails(ctx context.Context, nsm *nsManager, netnsPath, interfaceName, addrType string) (*net.IPNet, *net.HardwareAddr, error) {
 	// Try to retrieve ip inside container network namespace
-	output, err := exec.Command(nsm.nsenterPath, "--net="+netnsPath, "-F", "--",
+	output, err := exec.CommandContext(ctx, nsm.nsenterPath, "--net="+netnsPath, "-F", "--",
 		"ip", "-o", addrType, "addr", "show", "dev", interfaceName, "scope", "global").CombinedOutput()
 	if err != nil {
 		return nil, nil, fmt.Errorf("unexpected command output %s with error: %w", output, err)
@@ -41,7 +47,7 @@ func getContainerDetails(nsm *nsManager, netnsPath, interfaceName, addrType stri
 	}
 
 	fields := strings.Fields(lines[0])
-	if len(fields) < 4 {
+	if len(fields) < minIPAddrFields {
 		return nil, nil, fmt.Errorf("unexpected address output %s ", lines[0])
 	}
 
@@ -57,20 +63,20 @@ func getContainerDetails(nsm *nsManager, netnsPath, interfaceName, addrType stri
 	}
 
 	// Try to retrieve MAC inside container network namespace
-	output, err = exec.Command(nsm.nsenterPath, "--net="+netnsPath, "-F", "--",
+	output, err = exec.CommandContext(ctx, nsm.nsenterPath, "--net="+netnsPath, "-F", "--",
 		"ip", "link", "show", "dev", interfaceName).CombinedOutput()
 	if err != nil {
 		return nil, nil, fmt.Errorf("unexpected 'ip link' command output %s with error: %w", output, err)
 	}
 
 	lines = strings.Split(string(output), "\n")
-	if len(lines) < 2 {
+	if len(lines) < minLinkOutputLines {
 		return nil, nil, fmt.Errorf("unexpected 'ip link' command output %s", output)
 	}
 
 	fields = strings.Fields(lines[1])
-	if len(fields) < 4 {
-		return nil, nil, fmt.Errorf("unexpected link output %s ", lines[0])
+	if len(fields) < minLinkFields {
+		return nil, nil, fmt.Errorf("unexpected link output %s ", lines[1])
 	}
 
 	mac, err := net.ParseMAC(fields[1])
@@ -87,6 +93,7 @@ func bringUpLoopback(netns string) error {
 		if err == nil {
 			err = netlink.LinkSetUp(link)
 		}
+
 		if err != nil {
 			return err
 		}
@@ -95,6 +102,7 @@ func bringUpLoopback(netns string) error {
 		if err != nil {
 			return err
 		}
+
 		if len(v4Addrs) != 0 {
 			// sanity check that this is a loopback address
 			for _, addr := range v4Addrs {
@@ -108,6 +116,7 @@ func bringUpLoopback(netns string) error {
 		if err != nil {
 			return err
 		}
+
 		if len(v6Addrs) != 0 {
 			// sanity check that this is a loopback address
 			for _, addr := range v6Addrs {

--- a/tools/ocicnitool/ocicnitool.go
+++ b/tools/ocicnitool/ocicnitool.go
@@ -18,6 +18,11 @@ const (
 	CmdAdd    = "add"
 	CmdStatus = "status"
 	CmdDel    = "del"
+
+	// 1 command + 4 positional fields (pod_namespace, pod_name, pod_id, netns).
+	minRequiredArgs = 5
+
+	exitCodeUsage = 2
 )
 
 func printSandboxResults(results []ocicni.NetResult) {
@@ -43,6 +48,7 @@ func printSandboxResults(results []ocicni.NetResult) {
 
 func main() {
 	networksStr := flag.String("networks", "", "comma-separated list of CNI network names (optional)")
+
 	flag.Parse()
 
 	networks := make([]string, 0)
@@ -62,10 +68,9 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  %s [-networks name[,name...]] %s   <pod_namespace> <pod_name> <pod_id> <netns>\n", exe, CmdDel)
 	}
 
-	if len(flag.Args()) < 5 {
+	if len(flag.Args()) < minRequiredArgs {
 		flag.Usage()
-
-		return
+		os.Exit(exitCodeUsage)
 	}
 
 	confdir := os.Getenv(EnvConfDir)
@@ -113,6 +118,9 @@ func main() {
 		exit(err)
 	case CmdDel:
 		exit(plugin.TearDownPod(podNetwork))
+	default:
+		flag.Usage()
+		os.Exit(exitCodeUsage)
 	}
 }
 


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
Bumps golangci-lint from v2.0.1 to v2.11.4 and enables 13 new linters. Fixes all reported lint issues across the codebase.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code linting configuration to enforce stricter quality standards across the codebase.
  * Upgraded golangci-lint tooling to the latest stable version for improved code analysis.

* **Refactor**
  * Internal code improvements including structural reorganization and constant definitions for better maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->