### PR TITLE
Fix cross-platform compilation and minor bugs

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -141,7 +141,7 @@ func newWatcher(dirs []string) (*fsnotify.Watcher, error) {
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new watcher %w", err)
+		return nil, fmt.Errorf("failed to create new watcher: %w", err)
 	}
 
 	defer func() {

--- a/pkg/ocicni/util_freebsd.go
+++ b/pkg/ocicni/util_freebsd.go
@@ -4,6 +4,7 @@
 package ocicni
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os/exec"
@@ -16,14 +17,14 @@ func (nsm *nsManager) init() error {
 	return nil
 }
 
-func getContainerDetails(nsm *nsManager, netnsJailName, interfaceName, addrType string) (*net.IPNet, *net.HardwareAddr, error) {
+func getContainerDetails(ctx context.Context, nsm *nsManager, netnsJailName, interfaceName, addrType string) (*net.IPNet, *net.HardwareAddr, error) {
 	// Try to retrieve ip inside container network namespace
 	if addrType == "-4" {
 		addrType = "inet"
 	} else {
 		addrType = "inet6"
 	}
-	output, err := exec.Command(
+	output, err := exec.CommandContext(ctx,
 		"ifconfig", "-j", netnsJailName,
 		"-f", "inet:cidr,inet6:cidr",
 		interfaceName,
@@ -51,7 +52,7 @@ func getContainerDetails(nsm *nsManager, netnsJailName, interfaceName, addrType 
 	}
 
 	// Try to retrieve MAC inside container network namespace
-	output, err = exec.Command(
+	output, err = exec.CommandContext(ctx,
 		"ifconfig", "-j", netnsJailName, "-f", "inet:cidr,inet6:cidr",
 		interfaceName,
 		"ether").CombinedOutput()

--- a/pkg/ocicni/util_unsupported.go
+++ b/pkg/ocicni/util_unsupported.go
@@ -4,6 +4,7 @@
 package ocicni
 
 import (
+	"context"
 	"errors"
 	"net"
 )
@@ -17,12 +18,8 @@ func (nsm *nsManager) init() error {
 	return nil
 }
 
-func getContainerDetails(nsm *nsManager, netnsPath, interfaceName, addrType string) (*net.IPNet, *net.HardwareAddr, error) {
+func getContainerDetails(_ context.Context, nsm *nsManager, netnsPath, interfaceName, addrType string) (*net.IPNet, *net.HardwareAddr, error) {
 	return nil, nil, errUnsupportedPlatform
-}
-
-func tearDownLoopback(netns string) error {
-	return errUnsupportedPlatform
 }
 
 func bringUpLoopback(netns string) error {


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
- Fix `getContainerDetails` signature mismatch across platforms: the Linux version takes `context.Context` but FreeBSD and unsupported variants did not, causing compilation failures on non-Linux platforms. FreeBSD now also uses `exec.CommandContext` for proper context propagation.
- Fix missing colon in error format string at `newWatcher`
- Remove dead `tearDownLoopback` function from `util_unsupported.go`

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
None
```