### PR TITLE
Clean up CI, enable race detector, and add tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -151,6 +151,10 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      - path: _test\.go
+        linters:
+          - goconst
     paths:
       - third_party$
       - builtin$

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,5 @@
 GO ?= go
-EPOCH_TEST_COMMIT ?= b0fc980
 PROJECT := github.com/cri-o/ocicni
-GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
-GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
-OCICNI_IMAGE := ocicni_dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
-OCICNI_INSTANCE := ocicni_dev
 PREFIX ?= ${DESTDIR}/usr/local
 BINDIR ?= ${PREFIX}/bin
 LIBEXECDIR ?= ${PREFIX}/libexec
@@ -18,61 +13,25 @@ BUILD_PATH := $(shell pwd)/build
 GOLANGCI_LINT := ${BUILD_PATH}/golangci-lint
 GOLANGCI_LINT_VERSION := v2.11.4
 
-# If GOPATH not specified, use one in the local directory
-ifeq ($(GOPATH),)
-export GOPATH := $(CURDIR)/_output
-unexport GOBIN
-endif
-GOPKGDIR := $(GOPATH)/src/$(PROJECT)
-GOPKGBASEDIR := $(shell dirname "$(GOPKGDIR)")
-
-# Update VPATH so make finds .gopathok
-VPATH := $(VPATH):$(GOPATH)
-
 LDFLAGS := -ldflags '-X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_INFO}'
 
 all: binaries
-
-.gopathok:
-ifeq ("$(wildcard $(GOPKGDIR))","")
-	mkdir -p "$(GOPKGBASEDIR)"
-	ln -s "$(CURDIR)" "$(GOPKGBASEDIR)"
-endif
-	touch "$(GOPATH)/.gopathok"
 
 gofmt:
 	@./hack/verify-gofmt.sh
 
 binaries: ocicnitool
 
-ocicnitool: .gopathok $(shell hack/find-godeps.sh $(GOPKGDIR) tools/ocicnitool $(PROJECT))
+ocicnitool: $(shell hack/find-godeps.sh $(CURDIR) tools/ocicnitool $(PROJECT))
 	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/tools/ocicnitool
 
-check: .gopathok
-	@./hack/test-go.sh $(GOPKGDIR)
+check:
+	@./hack/test-go.sh $(CURDIR)
 	@./hack/verify-gofmt.sh
 	hack/tree_status.sh
 
 clean:
-ifneq ($(GOPATH),)
-	rm -f "$(GOPATH)/.gopathok"
-endif
 	rm -rf _output
-
-# When this is running in travis, it will only check the travis commit range
-.gitvalidation: .gopathok
-ifeq ($(TRAVIS),true)
-	GIT_CHECK_EXCLUDE="./vendor ./_output" $(GOPATH)/bin/git-validation -q -run DCO,short-subject,dangling-whitespace
-else
-	GIT_CHECK_EXCLUDE="./vendor ./_output" $(GOPATH)/bin/git-validation -v -run DCO,short-subject,dangling-whitespace -range $(EPOCH_TEST_COMMIT)..HEAD
-endif
-
-install.tools: .install.gitvalidation
-
-.install.gitvalidation: .gopathok
-	if [ ! -x "$(GOPATH)/bin/git-validation" ]; then \
-		go get -u github.com/vbatts/git-validation; \
-	fi
 
 vendor:
 	$(GO) mod tidy && \
@@ -97,7 +56,5 @@ lint:  ${GOLANGCI_LINT}
 	gofmt \
 	help \
 	check \
-	install.tools \
-	.gitvalidation \
 	vendor \
 	lint

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -13,11 +13,11 @@ if [ ! -z "${COVERALLS:-""}" ]; then
     echo "with coverage profile generation..."
     i=0
     for t in ${PKGS}; do
-        testrun "-covermode set -coverprofile ${i}.coverprofile ${t}"
+        testrun "-race -covermode atomic -coverprofile ${i}.coverprofile ${t}"
         i=$((i+1))
     done
 else
     echo "without coverage profile generation..."
-    testrun "./..."
+    testrun "-race ./..."
 fi
 

--- a/pkg/ocicni/ocicni_test.go
+++ b/pkg/ocicni/ocicni_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/types"
@@ -65,6 +67,7 @@ type fakePlugin struct {
 type fakeExec struct {
 	version.PluginDecoder
 
+	mu       sync.Mutex
 	addIndex int
 	delIndex int
 	chkIndex int
@@ -122,9 +125,9 @@ func getCNICommand(env []string) (string, error) {
 	return "", errors.New("failed to find CNI_COMMAND")
 }
 
-func (f *fakeExec) ExecPlugin(ctx context.Context, pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
-	cmd, err := getCNICommand(environ)
-	Expect(err).NotTo(HaveOccurred())
+func (f *fakeExec) nextPlugin(cmd string) *fakePlugin {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 
 	var index int
 
@@ -145,8 +148,19 @@ func (f *fakeExec) ExecPlugin(ctx context.Context, pluginPath string, stdinData 
 		Expect(len(f.plugins)).To(BeNumerically(">", f.gcIndex))
 		index = f.gcIndex
 		f.gcIndex++
+	default:
+		Expect(false).To(BeTrue())
+	}
+
+	return f.plugins[index]
+}
+
+func (f *fakeExec) ExecPlugin(ctx context.Context, pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
+	cmd, err := getCNICommand(environ)
+	Expect(err).NotTo(HaveOccurred())
+
+	switch cmd {
 	case "VERSION":
-		// Just return all supported versions
 		return json.Marshal(version.All)
 	case "STATUS":
 		if f.failStatus {
@@ -154,14 +168,11 @@ func (f *fakeExec) ExecPlugin(ctx context.Context, pluginPath string, stdinData 
 		}
 
 		return nil, nil
-	default:
-		// Should never be reached
-		Expect(false).To(BeTrue())
 	}
 
-	plugin := f.plugins[index]
+	plugin := f.nextPlugin(cmd)
 
-	GinkgoT().Logf("[%s %d] exec plugin %q found %+v", cmd, index, pluginPath, plugin)
+	GinkgoT().Logf("[%s] exec plugin %q found %+v", cmd, pluginPath, plugin)
 
 	// SetUpPod We only care about a few fields
 	testConf := &TestConf{}
@@ -708,6 +719,135 @@ var _ = Describe("ocicni operations", func() {
 		Expect(fake.delIndex).To(Equal(len(fake.plugins)))
 
 		Expect(ocicni.Shutdown()).NotTo(HaveOccurred())
+	})
+
+	It("sets up and tears down pod with context using default network", func() {
+		conf, _, err := writeConfig(tmpDir, "10-network2.conf", "network2", "myplugin", "0.4.0")
+		Expect(err).NotTo(HaveOccurred())
+
+		fake := &fakeExec{}
+		expectedResult := &cniv04.Result{
+			CNIVersion: "0.4.0",
+			Interfaces: []*cniv04.Interface{
+				{
+					Name:    "eth0",
+					Mac:     "01:23:45:67:89:01",
+					Sandbox: networkNS.Path(),
+				},
+			},
+			IPs: []*cniv04.IPConfig{
+				{
+					Interface: cniv04.Int(0),
+					Version:   "4",
+					Address:   *ensureCIDR("1.1.1.2/24"),
+				},
+			},
+		}
+		fake.addPlugin(nil, conf, expectedResult)
+
+		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, true, "/opt/cni/bin")
+		Expect(err).NotTo(HaveOccurred())
+
+		podNet := PodNetwork{
+			Name:      "pod1",
+			Namespace: "namespace1",
+			ID:        "1234567890",
+			UID:       "9414bd03-b3d3-453e-9d9f-47dcee07958c",
+			NetNS:     networkNS.Path(),
+		}
+
+		ctx := context.Background()
+		results, err := ocicni.SetUpPodWithContext(ctx, podNet)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(results).To(HaveLen(1))
+		r, ok := results[0].Result.(*cniv04.Result)
+		Expect(ok).To(BeTrue())
+		Expect(reflect.DeepEqual(r, expectedResult)).To(BeTrue())
+
+		err = ocicni.TearDownPodWithContext(ctx, podNet)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(ocicni.Shutdown()).NotTo(HaveOccurred())
+	})
+
+	It("handles concurrent pod operations safely", func() {
+		conf, _, err := writeConfig(tmpDir, "10-network2.conf", "network2", "myplugin", "0.4.0")
+		Expect(err).NotTo(HaveOccurred())
+
+		const goroutines = 10
+
+		fake := &fakeExec{}
+
+		addResult := &cniv04.Result{
+			CNIVersion: "0.4.0",
+			Interfaces: []*cniv04.Interface{
+				{
+					Name:    "eth0",
+					Mac:     "01:23:45:67:89:01",
+					Sandbox: networkNS.Path(),
+				},
+			},
+			IPs: []*cniv04.IPConfig{
+				{
+					Interface: cniv04.Int(0),
+					Version:   "4",
+					Address:   *ensureCIDR("1.1.1.2/24"),
+				},
+			},
+		}
+
+		for range goroutines {
+			fake.addPlugin(nil, conf, addResult)
+		}
+
+		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, true, "/opt/cni/bin")
+		Expect(err).NotTo(HaveOccurred())
+
+		defer func() {
+			Expect(ocicni.Shutdown()).NotTo(HaveOccurred())
+		}()
+
+		Eventually(func() bool {
+			return ocicni.Status() == nil
+		}, 5*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+		var wg sync.WaitGroup
+
+		wg.Add(goroutines)
+
+		errCh := make(chan error, goroutines*2)
+
+		for i := range goroutines {
+			go func() {
+				defer wg.Done()
+
+				podNet := PodNetwork{
+					Name:      fmt.Sprintf("pod%d", i),
+					Namespace: "namespace1",
+					ID:        fmt.Sprintf("pod-id-%d", i),
+					NetNS:     networkNS.Path(),
+				}
+
+				_, setupErr := ocicni.SetUpPod(podNet)
+				if setupErr != nil {
+					errCh <- setupErr
+
+					return
+				}
+
+				teardownErr := ocicni.TearDownPod(podNet)
+				if teardownErr != nil {
+					errCh <- teardownErr
+				}
+			}()
+		}
+
+		wg.Wait()
+		close(errCh)
+
+		for err := range errCh {
+			Expect(err).NotTo(HaveOccurred())
+		}
 	})
 
 	It("sets up and tears down a pod using specified networks", func() {


### PR DESCRIPTION
/kind cleanup
/kind ci

#### What this PR does / why we need it:
- Remove legacy Makefile patterns: Travis CI references, GOPATH symlinking (`.gopathok`), `install.tools` target, and unused variables
- Enable `-race` flag in test runner (with `-covermode atomic` as required)
- Replace deprecated `gomodguard` linter with `gomodguard_v2`
- Add test for `SetUpPodWithContext`/`TearDownPodWithContext` API variants
- Add concurrent pod operations test exercising the pod lock mechanism

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test coverage for pod lifecycle operations, including concurrent scenarios
  * Enhanced test execution with improved race detection and coverage analysis

* **Chores**
  * Simplified build workflow and dependency management infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->