### PR TITLE
Fix error wrapping, deprecated APIs, and logging consistency

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
 	"path"
@@ -330,7 +331,7 @@ func loadNetworks(ctx context.Context, confDir string, cni *libcni.CNIConfig) (n
 			confList, err = libcni.ConfListFromFile(confFile)
 			if err != nil {
 				// do not log ENOENT errors
-				if !os.IsNotExist(err) {
+				if !errors.Is(err, fs.ErrNotExist) {
 					logrus.Errorf("Error loading CNI config list file %s: %v", confFile, err)
 				}
 
@@ -347,7 +348,7 @@ func loadNetworks(ctx context.Context, confDir string, cni *libcni.CNIConfig) (n
 			conf, err := libcni.NetworkPluginConfFromBytes(bytes)
 			if err != nil {
 				// do not log ENOENT errors
-				if !os.IsNotExist(err) {
+				if !errors.Is(err, fs.ErrNotExist) {
 					logrus.Errorf("Error loading CNI config file %s: %v", confFile, err)
 				}
 
@@ -372,7 +373,7 @@ func loadNetworks(ctx context.Context, confDir string, cni *libcni.CNIConfig) (n
 		// Validation on CNI config should be done to pre-check presence
 		// of plugins which are necessary.
 		if _, err := cni.ValidateNetworkList(ctx, confList); err != nil {
-			logrus.Warningf("Error validating CNI config file %s: %v", confFile, err)
+			logrus.Warnf("Error validating CNI config file %s: %v", confFile, err)
 
 			continue
 		}
@@ -606,7 +607,7 @@ func (plugin *cniNetworkPlugin) forEachNetwork(ctx context.Context, podNetwork *
 			cniNet, newRt, err = plugin.loadNetworkFromCache(network.Name, rt)
 			if err != nil {
 				logrus.Errorf("Error loading cached network config: %v", err)
-				logrus.Warningf("Falling back to loading from existing plugins on disk")
+				logrus.Warnf("Falling back to loading from existing plugins on disk")
 			} else {
 				// Use the updated RuntimeConf
 				rt = newRt
@@ -732,7 +733,7 @@ func (plugin *cniNetworkPlugin) getCachedNetworkInfo(containerID string) ([]NetA
 		}
 
 		if cachedInfo.Kind != libcni.CNICacheV1 {
-			logrus.Warningf("Unknown CNI cache file %s kind %q", cacheFile, cachedInfo.Kind)
+			logrus.Warnf("Unknown CNI cache file %s kind %q", cacheFile, cachedInfo.Kind)
 
 			continue
 		}
@@ -746,7 +747,7 @@ func (plugin *cniNetworkPlugin) getCachedNetworkInfo(containerID string) ([]NetA
 		}
 
 		if cachedInfo.IfName == "" || cachedInfo.NetName == "" {
-			logrus.Warningf("Missing CNI cache file %s ifname %q or netname %q", cacheFile, cachedInfo.IfName, cachedInfo.NetName)
+			logrus.Warnf("Missing CNI cache file %s ifname %q or netname %q", cacheFile, cachedInfo.IfName, cachedInfo.NetName)
 
 			continue
 		}
@@ -963,7 +964,7 @@ func (network *cniNetwork) checkNetwork(ctx context.Context, rt *libcni.RuntimeC
 	}
 
 	if cniInterface == nil || len(ips) == 0 {
-		return nil, fmt.Errorf("neither IPv4 nor IPv6 found when retrieving network status: %v", errs)
+		return nil, fmt.Errorf("neither IPv4 nor IPv6 found when retrieving network status: %w", errors.Join(errs...))
 	}
 
 	result = &cniv1.Result{
@@ -998,7 +999,7 @@ func buildCNIRuntimeConf(podNetwork *PodNetwork, ifName string, runtimeConfig *R
 		runtimeConfig = &RuntimeConfig{}
 	}
 
-	logrus.Infof("Got pod network %+v", podNetwork)
+	logrus.Debugf("Got pod network %+v", podNetwork)
 
 	rt := &libcni.RuntimeConf{
 		ContainerID: podNetwork.ID,

--- a/pkg/ocicni/util_freebsd.go
+++ b/pkg/ocicni/util_freebsd.go
@@ -29,20 +29,20 @@ func getContainerDetails(nsm *nsManager, netnsJailName, interfaceName, addrType 
 		interfaceName,
 		addrType).CombinedOutput()
 	if err != nil {
-		return nil, nil, fmt.Errorf("Unexpected command output %s with error: %v", output, err)
+		return nil, nil, fmt.Errorf("unexpected command output %s with error: %w", output, err)
 	}
 
 	lines := strings.Split(string(output), "\n")
 	if len(lines) < 3 {
-		return nil, nil, fmt.Errorf("Unexpected command output %s", output)
+		return nil, nil, fmt.Errorf("unexpected command output %s", output)
 	}
 	fields := strings.Fields(strings.TrimSpace(lines[2]))
 	if len(fields) < 2 {
-		return nil, nil, fmt.Errorf("Unexpected address output %s ", lines[0])
+		return nil, nil, fmt.Errorf("unexpected address output %s ", lines[0])
 	}
 	ip, ipNet, err := net.ParseCIDR(fields[1])
 	if err != nil {
-		return nil, nil, fmt.Errorf("CNI failed to parse ip from output %s due to %v", output, err)
+		return nil, nil, fmt.Errorf("failed to parse ip from output %s due to %w", output, err)
 	}
 	if ip.To4() == nil {
 		ipNet.IP = ip
@@ -56,7 +56,7 @@ func getContainerDetails(nsm *nsManager, netnsJailName, interfaceName, addrType 
 		interfaceName,
 		"ether").CombinedOutput()
 	if err != nil {
-		return nil, nil, fmt.Errorf("unexpected ifconfig command output %s with error: %v", output, err)
+		return nil, nil, fmt.Errorf("unexpected ifconfig command output %s with error: %w", output, err)
 	}
 
 	lines = strings.Split(string(output), "\n")
@@ -69,7 +69,7 @@ func getContainerDetails(nsm *nsManager, netnsJailName, interfaceName, addrType 
 	}
 	mac, err := net.ParseMAC(fields[1])
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse MAC from output %s due to %v", output, err)
+		return nil, nil, fmt.Errorf("failed to parse MAC from output %s due to %w", output, err)
 	}
 
 	return ipNet, &mac, nil


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
- Replace `%v` with `%w` in `fmt.Errorf` calls for proper error wrapping (`util_freebsd.go` and `ocicni.go`)
- Use `errors.Join` for joining `[]error` slice in `checkNetwork`
- Replace `os.IsNotExist` with `errors.Is(err, fs.ErrNotExist)` (modern Go pattern that works with wrapped errors)
- Standardize `logrus.Warningf` to `logrus.Warnf` throughout
- Demote hot-path `"Got pod network"` log from Info to Debug level
- Lowercase error messages in `util_freebsd.go` to follow Go conventions

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
This PR touches `util_freebsd.go` which is also modified by #314. Merge #314 first, then rebase this PR to resolve the trivial conflict on the `getContainerDetails` function signature line.

#### Does this PR introduce a user-facing change?
```release-note
None
```