### PR TITLE
Update golangci-lint to v2.12.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,7 +45,7 @@ linters:
     - godox
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosmopolitan
     - govet
@@ -105,6 +105,7 @@ linters:
     - whitespace
     - wsl_v5
     - zerologlint
+    # - clickhouselint
     # - depguard
     # - err113
     # - exhaustruct
@@ -151,6 +152,10 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      - path: _test\.go
+        linters:
+          - goconst
     paths:
       - third_party$
       - builtin$

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ BUILD_INFO := $(shell date +%s)
 
 BUILD_PATH := $(shell pwd)/build
 GOLANGCI_LINT := ${BUILD_PATH}/golangci-lint
-GOLANGCI_LINT_VERSION := v2.11.4
+GOLANGCI_LINT_VERSION := v2.12.2
 
 # If GOPATH not specified, use one in the local directory
 ifeq ($(GOPATH),)
@@ -81,9 +81,9 @@ vendor:
 
 $(GOLANGCI_LINT):
 	export VERSION=$(GOLANGCI_LINT_VERSION) \
-		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
+		URL=https://golangci-lint.run \
 		BINDIR=${BUILD_PATH} && \
-	curl -sSfL $$URL/$$VERSION/install.sh | sh -s $$VERSION
+	curl -sSfL $$URL/install.sh | sh -s $$VERSION
 
 lint:  ${GOLANGCI_LINT}
 	${GOLANGCI_LINT} version


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
Bumps golangci-lint from v2.11.4 to v2.12.2 and updates the configuration:
- Replace deprecated `gomodguard` with `gomodguard_v2`
- Switch install script URL to stable `https://golangci-lint.run`
- Exclude `goconst` from test files via exclusion rule

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
None
```