### PR TITLE
Fix cross-platform compilation, add SetUpPod rollback, and harden monitoring

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,27 @@ jobs:
       - name: Build on ${{ matrix.arch }}
         run: make GOARCH=${{ matrix.arch }}
 
+  build-cross-platform:
+    name: Build / ${{ matrix.goos }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        goos:
+          - freebsd
+          - windows
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - name: Build on ${{ matrix.goos }}
+        run: CGO_ENABLED=0 GOOS=${{ matrix.goos }} go build ./...
+
   test-linux:
     name: Run tests on Linux amd64
     runs-on: ubuntu-latest
@@ -39,9 +60,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install test binaries
-        run: |
-          go install github.com/modocache/gover@latest
-          go install github.com/mattn/goveralls@latest
+        run: go install github.com/mattn/goveralls@latest
 
       - name: test
         run: PATH=$PATH:$(go env GOPATH)/bin COVERALLS=1 make check
@@ -52,8 +71,7 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PATH=$PATH:$(go env GOPATH)/bin
-          gover
-          goveralls -coverprofile=gover.coverprofile -service=github
+          goveralls -coverprofile=coverage.out -service=github
 
   lint:
     name: Run golangci-lint

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 *.orig
 ocicnitool
 *.coverprofile
+coverage.out
 *.test

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -8,16 +8,9 @@ function testrun {
     sudo -E bash -c "umask 0; PATH=$PATH go test $@"
 }
 if [ ! -z "${COVERALLS:-""}" ]; then
-    # coverage profile only works per-package
-    PKGS="$(go list ./... | xargs echo)"
     echo "with coverage profile generation..."
-    i=0
-    for t in ${PKGS}; do
-        testrun "-race -covermode atomic -coverprofile ${i}.coverprofile ${t}"
-        i=$((i+1))
-    done
+    testrun "-race -covermode atomic -coverprofile coverage.out ./..."
 else
     echo "without coverage profile generation..."
     testrun "-race ./..."
 fi
-

--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -208,8 +208,6 @@ func (plugin *cniNetworkPlugin) monitorConfDir(ctx context.Context, start *sync.
 
 			logrus.Errorf("CNI monitoring error %v", err)
 
-			return
-
 		case <-plugin.shutdownChan:
 			return
 		}
@@ -404,9 +402,12 @@ func loadNetworks(ctx context.Context, confDir string, cni *libcni.CNIConfig) (n
 	return networks, defaultNetName, nil
 }
 
-const loIfname string = "lo"
+const loIfname = "lo"
 
-const keyValuePairLen = 2
+const (
+	keyValuePairLen = 2
+	maxIfaceNum     = 10000
+)
 
 func (plugin *cniNetworkPlugin) syncNetworkConfig(ctx context.Context) error {
 	networks, defaultNetName, err := loadNetworks(ctx, plugin.confDir, plugin.cniConfig)
@@ -537,7 +538,7 @@ func (plugin *cniNetworkPlugin) fillPodNetworks(podNetwork *PodNetwork) error {
 netLoop:
 	for i, network := range podNetwork.Networks {
 		if network.Ifname == "" {
-			for j := range 10000 {
+			for j := range maxIfaceNum {
 				candidate := fmt.Sprintf("eth%d", j)
 				if !allIfNames[candidate] {
 					allIfNames[candidate] = true
@@ -653,7 +654,14 @@ func (plugin *cniNetworkPlugin) SetUpPodWithContext(ctx context.Context, podNetw
 		return nil, err
 	}
 
+	type attached struct {
+		network *cniNetwork
+		rt      *libcni.RuntimeConf
+	}
+
 	results := make([]NetResult, 0)
+
+	var rollback []attached
 
 	if err := plugin.forEachNetwork(ctx, &podNetwork, false, func(network *cniNetwork, podNetwork *PodNetwork, rt *libcni.RuntimeConf) error {
 		fullPodName := buildFullPodName(podNetwork)
@@ -663,6 +671,8 @@ func (plugin *cniNetworkPlugin) SetUpPodWithContext(ctx context.Context, podNetw
 		if err != nil {
 			return fmt.Errorf("error adding pod %s to CNI network %q: %w", fullPodName, network.name, err)
 		}
+
+		rollback = append(rollback, attached{network: network, rt: rt})
 
 		results = append(results, NetResult{
 			Result: result,
@@ -674,6 +684,13 @@ func (plugin *cniNetworkPlugin) SetUpPodWithContext(ctx context.Context, podNetw
 
 		return nil
 	}); err != nil {
+		cleanupCtx := context.WithoutCancel(ctx)
+		for _, a := range slices.Backward(rollback) {
+			if delErr := a.network.deleteFromNetwork(cleanupCtx, a.rt, plugin.cniConfig); delErr != nil {
+				logrus.Errorf("Error rolling back pod network %q: %v", a.network.name, delErr)
+			}
+		}
+
 		return nil, err
 	}
 

--- a/pkg/ocicni/ocicni_test.go
+++ b/pkg/ocicni/ocicni_test.go
@@ -222,6 +222,15 @@ func ensureCIDR(cidr string) *net.IPNet {
 	return network
 }
 
+const (
+	testPodName      = "pod1"
+	testPodNamespace = "namespace1"
+	testPodUID       = "9414bd03-b3d3-453e-9d9f-47dcee07958c"
+	testCNIVersion   = "0.3.1"
+	testMAC          = "01:23:45:67:89:01"
+	testBinDir       = "/opt/cni/bin"
+)
+
 var _ = Describe("ocicni operations", func() {
 	var (
 		tmpDir    string
@@ -259,12 +268,12 @@ var _ = Describe("ocicni operations", func() {
 	})
 
 	It("finds an existing default network configuration", func() {
-		_, _, err := writeConfig(tmpDir, "5-notdefault.conf", "notdefault", "myplugin", "0.3.1")
+		_, _, err := writeConfig(tmpDir, "5-notdefault.conf", "notdefault", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
-		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "myplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 
-		ocicni, err := initCNI(&fakeExec{}, "", "test", tmpDir, false, "/opt/cni/bin")
+		ocicni, err := initCNI(&fakeExec{}, "", "test", tmpDir, false, testBinDir)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ocicni.Status()).NotTo(HaveOccurred())
 
@@ -281,15 +290,15 @@ var _ = Describe("ocicni operations", func() {
 	})
 
 	It("finds an asynchronously written default network configuration", func() {
-		ocicni, err := initCNI(&fakeExec{}, "", "test", tmpDir, true, "/opt/cni/bin")
+		ocicni, err := initCNI(&fakeExec{}, "", "test", tmpDir, true, testBinDir)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Writing a config that doesn't match the default network
-		_, _, err = writeConfig(tmpDir, "5-notdefault.conf", "notdefault", "myplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "5-notdefault.conf", "notdefault", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 		Consistently(ocicni.Status, 5).Should(HaveOccurred())
 
-		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "myplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(ocicni.Status, 5).Should(Succeed())
 
@@ -309,7 +318,7 @@ var _ = Describe("ocicni operations", func() {
 		ocicni, err := initCNI(fExec, "", "test", tmpDir, true, tmpBinDir)
 		Expect(err).NotTo(HaveOccurred())
 
-		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "myplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 		Consistently(ocicni.Status, 5).ShouldNot(Succeed())
 
@@ -346,12 +355,12 @@ var _ = Describe("ocicni operations", func() {
 
 	//nolint:dupl // no need to dedup for tests
 	It("should monitor the net conf dir for changes when default network is not specified", func() {
-		_, _, err := writeConfig(tmpDir, "5-notdefault.conf", "notdefault", "myplugin", "0.3.1")
+		_, _, err := writeConfig(tmpDir, "5-notdefault.conf", "notdefault", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
-		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "myplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 
-		ocicni, err := initCNI(&fakeExec{}, "", "", tmpDir, true, "/opt/cni/bin")
+		ocicni, err := initCNI(&fakeExec{}, "", "", tmpDir, true, testBinDir)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ocicni.Status()).NotTo(HaveOccurred())
 
@@ -365,7 +374,7 @@ var _ = Describe("ocicni operations", func() {
 		Expect(net.config.Plugins[0].Network.Type).To(Equal("myplugin"))
 
 		// If a CNI config file is updated, default network name should be reloaded real-time
-		_, _, err = writeConfig(tmpDir, "10-test.conf", "secondary", "testplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "10-test.conf", "secondary", "testplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 
 		Consistently(ocicni.Status, 5).Should(Succeed())
@@ -380,12 +389,12 @@ var _ = Describe("ocicni operations", func() {
 
 	//nolint:dupl // no need to dedup for tests
 	It("should monitor the net conf dir for changes when default network is specified", func() {
-		_, _, err := writeConfig(tmpDir, "5-notdefault.conf", "notdefault", "myplugin", "0.3.1")
+		_, _, err := writeConfig(tmpDir, "5-notdefault.conf", "notdefault", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
-		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "myplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 
-		ocicni, err := initCNI(&fakeExec{}, "", "test", tmpDir, true, "/opt/cni/bin")
+		ocicni, err := initCNI(&fakeExec{}, "", "test", tmpDir, true, testBinDir)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ocicni.Status()).NotTo(HaveOccurred())
 
@@ -399,7 +408,7 @@ var _ = Describe("ocicni operations", func() {
 		Expect(net.config.Plugins[0].Network.Type).To(Equal("myplugin"))
 
 		// If a CNI config file is updated, default network name should be reloaded real-time
-		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "testplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "10-test.conf", "test", "testplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 
 		Consistently(ocicni.Status, 5).Should(Succeed())
@@ -414,14 +423,14 @@ var _ = Describe("ocicni operations", func() {
 
 	It("finds and refinds an asynchronously written default network configuration", func() {
 		f := &fakeExec{}
-		ocicni, err := initCNI(f, "", "test", tmpDir, true, "/opt/cni/bin")
+		ocicni, err := initCNI(f, "", "test", tmpDir, true, testBinDir)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = ocicni.Status()
 		Expect(err).To(HaveOccurred())
 
 		// Write the default network config
-		_, confPath, err := writeConfig(tmpDir, "10-test.conf", "test", "myplugin", "0.3.1")
+		_, confPath, err := writeConfig(tmpDir, "10-test.conf", "test", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(ocicni.Status, 5).Should(Succeed())
 
@@ -457,12 +466,12 @@ var _ = Describe("ocicni operations", func() {
 	})
 
 	It("finds an ASCIIbetically first network configuration as default real-time if given no default network name", func() {
-		ocicni, err := initCNI(&fakeExec{}, "", "", tmpDir, true, "/opt/cni/bin")
+		ocicni, err := initCNI(&fakeExec{}, "", "", tmpDir, true, testBinDir)
 		Expect(err).NotTo(HaveOccurred())
 
-		_, _, err = writeConfig(tmpDir, "15-test.conf", "test", "myplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "15-test.conf", "test", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
-		_, _, err = writeConfig(tmpDir, "5-notdefault.conf", "notdefault", "myplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "5-notdefault.conf", "notdefault", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(ocicni.Status, 5).Should(Succeed())
@@ -477,7 +486,7 @@ var _ = Describe("ocicni operations", func() {
 
 		// If a new CNI config file is added, default network name should be reloaded real-time
 		// by file sorting
-		_, _, err = writeConfig(tmpDir, "10-abc.conf", "newdefault", "myplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "10-abc.conf", "newdefault", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 
 		Consistently(ocicni.Status, 5).Should(Succeed())
@@ -492,16 +501,16 @@ var _ = Describe("ocicni operations", func() {
 
 	It("returns correct default network from loadNetworks()", func() {
 		// Writing a config that doesn't match the default network
-		_, _, err := writeConfig(tmpDir, "5-network1.conf", "network1", "myplugin", "0.3.1")
+		_, _, err := writeConfig(tmpDir, "5-network1.conf", "network1", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
-		_, _, err = writeConfig(tmpDir, "10-network2.conf", "network2", "myplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "10-network2.conf", "network2", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
-		_, _, err = writeConfig(tmpDir, "30-network3.conf", "network3", "myplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "30-network3.conf", "network3", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
-		_, _, err = writeConfig(tmpDir, "afdsfdsafdsa-network3.conf", "network4", "myplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "afdsfdsafdsa-network3.conf", "network4", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 
-		cniConfig := libcni.NewCNIConfig([]string{"/opt/cni/bin"}, &fakeExec{})
+		cniConfig := libcni.NewCNIConfig([]string{testBinDir}, &fakeExec{})
 		netMap, defname, err := loadNetworks(context.TODO(), tmpDir, cniConfig)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(netMap).To(HaveLen(4))
@@ -510,7 +519,7 @@ var _ = Describe("ocicni operations", func() {
 	})
 
 	It("returns no error from loadNetworks() when no config files exist", func() {
-		cniConfig := libcni.NewCNIConfig([]string{"/opt/cni/bin"}, &fakeExec{})
+		cniConfig := libcni.NewCNIConfig([]string{testBinDir}, &fakeExec{})
 		netMap, defname, err := loadNetworks(context.TODO(), tmpDir, cniConfig)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(netMap).To(BeEmpty())
@@ -520,14 +529,14 @@ var _ = Describe("ocicni operations", func() {
 
 	It("ignores subsequent duplicate network names in loadNetworks()", func() {
 		// Writing a config that doesn't match the default network
-		_, _, err := writeConfig(tmpDir, "10-network2.conf", "network2", "myplugin", "0.3.1")
+		_, _, err := writeConfig(tmpDir, "10-network2.conf", "network2", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
-		_, _, err = writeConfig(tmpDir, "30-network3.conf", "network3", "myplugin", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "30-network3.conf", "network3", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
-		_, _, err = writeConfig(tmpDir, "5-network1.conf", "network2", "myplugin2", "0.3.1")
+		_, _, err = writeConfig(tmpDir, "5-network1.conf", "network2", "myplugin2", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 
-		cniConfig := libcni.NewCNIConfig([]string{"/opt/cni/bin"}, &fakeExec{})
+		cniConfig := libcni.NewCNIConfig([]string{testBinDir}, &fakeExec{})
 		netMap, _, err := loadNetworks(context.TODO(), tmpDir, cniConfig)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -540,7 +549,7 @@ var _ = Describe("ocicni operations", func() {
 	})
 
 	It("build different runtime configs", func() {
-		ifName := "eth0"
+		ifName := DefaultInterfaceName
 		podNetwork := &PodNetwork{}
 
 		var (
@@ -661,16 +670,16 @@ var _ = Describe("ocicni operations", func() {
 	})
 
 	It("sets up and tears down a pod using the default network", func() {
-		conf, _, err := writeConfig(tmpDir, "10-network2.conf", "network2", "myplugin", "0.3.1")
+		conf, _, err := writeConfig(tmpDir, "10-network2.conf", "network2", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 
 		fake := &fakeExec{}
 		expectedResult := &cniv04.Result{
-			CNIVersion: "0.3.1",
+			CNIVersion: testCNIVersion,
 			Interfaces: []*cniv04.Interface{
 				{
-					Name:    "eth0",
-					Mac:     "01:23:45:67:89:01",
+					Name:    DefaultInterfaceName,
+					Mac:     testMAC,
 					Sandbox: networkNS.Path(),
 				},
 			},
@@ -684,14 +693,14 @@ var _ = Describe("ocicni operations", func() {
 		}
 		fake.addPlugin(nil, conf, expectedResult)
 
-		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, true, "/opt/cni/bin")
+		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, true, testBinDir)
 		Expect(err).NotTo(HaveOccurred())
 
 		podNet := PodNetwork{
-			Name:      "pod1",
-			Namespace: "namespace1",
+			Name:      testPodName,
+			Namespace: testPodNamespace,
 			ID:        "1234567890",
-			UID:       "9414bd03-b3d3-453e-9d9f-47dcee07958c",
+			UID:       testPodUID,
 			NetNS:     networkNS.Path(),
 		}
 		results, err := ocicni.SetUpPod(podNet)
@@ -851,21 +860,21 @@ var _ = Describe("ocicni operations", func() {
 	})
 
 	It("sets up and tears down a pod using specified networks", func() {
-		_, _, err := writeConfig(tmpDir, "10-network2.conf", "network2", "myplugin", "0.3.1")
+		_, _, err := writeConfig(tmpDir, "10-network2.conf", "network2", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 
-		conf1, _, err := writeConfig(tmpDir, "20-network3.conf", "network3", "myplugin", "0.3.1")
+		conf1, _, err := writeConfig(tmpDir, "20-network3.conf", "network3", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
-		conf2, _, err := writeConfig(tmpDir, "30-network4.conf", "network4", "myplugin", "0.3.1")
+		conf2, _, err := writeConfig(tmpDir, "30-network4.conf", "network4", "myplugin", testCNIVersion)
 		Expect(err).NotTo(HaveOccurred())
 
 		fake := &fakeExec{}
 		expectedResult1 := &cniv04.Result{
-			CNIVersion: "0.3.1",
+			CNIVersion: testCNIVersion,
 			Interfaces: []*cniv04.Interface{
 				{
-					Name:    "eth0",
-					Mac:     "01:23:45:67:89:01",
+					Name:    DefaultInterfaceName,
+					Mac:     testMAC,
 					Sandbox: networkNS.Path(),
 				},
 			},
@@ -880,7 +889,7 @@ var _ = Describe("ocicni operations", func() {
 		fake.addPlugin(nil, conf1, expectedResult1)
 
 		expectedResult2 := &cniv04.Result{
-			CNIVersion: "0.3.1",
+			CNIVersion: testCNIVersion,
 			Interfaces: []*cniv04.Interface{
 				{
 					Name:    "eth1",
@@ -897,14 +906,14 @@ var _ = Describe("ocicni operations", func() {
 		}
 		fake.addPlugin(nil, conf2, expectedResult2)
 
-		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, true, "/opt/cni/bin")
+		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, true, testBinDir)
 		Expect(err).NotTo(HaveOccurred())
 
 		podNet := PodNetwork{
-			Name:      "pod1",
-			Namespace: "namespace1",
+			Name:      testPodName,
+			Namespace: testPodNamespace,
 			ID:        "1234567890",
-			UID:       "9414bd03-b3d3-453e-9d9f-47dcee07958c",
+			UID:       testPodUID,
 			NetNS:     networkNS.Path(),
 			Networks: []NetAttachment{
 				{Name: "network3"},
@@ -943,8 +952,8 @@ var _ = Describe("ocicni operations", func() {
 			CNIVersion: "0.4.0",
 			Interfaces: []*cniv04.Interface{
 				{
-					Name:    "eth0",
-					Mac:     "01:23:45:67:89:01",
+					Name:    DefaultInterfaceName,
+					Mac:     testMAC,
 					Sandbox: networkNS.Path(),
 				},
 			},
@@ -977,14 +986,14 @@ var _ = Describe("ocicni operations", func() {
 		}
 		fake.addPlugin(nil, conf2, expectedResult2)
 
-		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, true, "/opt/cni/bin")
+		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, true, testBinDir)
 		Expect(err).NotTo(HaveOccurred())
 
 		podNet := PodNetwork{
-			Name:      "pod1",
-			Namespace: "namespace1",
+			Name:      testPodName,
+			Namespace: testPodNamespace,
 			ID:        "1234567890",
-			UID:       "9414bd03-b3d3-453e-9d9f-47dcee07958c",
+			UID:       testPodUID,
 			NetNS:     networkNS.Path(),
 			Networks: []NetAttachment{
 				{Name: "network3"},
@@ -1036,14 +1045,14 @@ var _ = Describe("ocicni operations", func() {
 
 		fake.addPlugin(nil, expectedConf, nil)
 
-		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, true, "/opt/cni/bin")
+		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, true, testBinDir)
 		Expect(err).NotTo(HaveOccurred())
 
 		podNet := PodNetwork{
-			Name:      "pod1",
-			Namespace: "namespace1",
+			Name:      testPodName,
+			Namespace: testPodNamespace,
 			ID:        "1234567890",
-			UID:       "9414bd03-b3d3-453e-9d9f-47dcee07958c",
+			UID:       testPodUID,
 			NetNS:     networkNS.Path(),
 		}
 		err = ocicni.GC(context.Background(), []*PodNetwork{&podNet})
@@ -1068,14 +1077,14 @@ var _ = Describe("ocicni operations", func() {
 
 		fake.addPlugin(nil, expectedConf, nil)
 
-		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, true, "/opt/cni/bin")
+		ocicni, err := initCNI(fake, cacheDir, "network2", tmpDir, true, testBinDir)
 		Expect(err).NotTo(HaveOccurred())
 
 		podNet := PodNetwork{
-			Name:      "pod1",
-			Namespace: "namespace1",
+			Name:      testPodName,
+			Namespace: testPodNamespace,
 			ID:        "1234567890",
-			UID:       "9414bd03-b3d3-453e-9d9f-47dcee07958c",
+			UID:       testPodUID,
 			NetNS:     networkNS.Path(),
 			Networks: []NetAttachment{
 				{Name: "network2", Ifname: "net1"},
@@ -1104,7 +1113,7 @@ var _ = Describe("ocicni operations", func() {
 
 		BeforeEach(func() {
 			// Unused default config
-			_, _, err := writeConfig(tmpDir, "10-test.conf", defaultNetName, "myplugin", "0.3.1")
+			_, _, err := writeConfig(tmpDir, "10-test.conf", defaultNetName, "myplugin", testCNIVersion)
 			Expect(err).NotTo(HaveOccurred())
 
 			conf1 := fmt.Sprintf(`{
@@ -1125,14 +1134,14 @@ var _ = Describe("ocicni operations", func() {
 			fake.addPlugin([]string{"CNI_IFNAME=" + ifname1}, conf1, nil)
 			fake.addPlugin([]string{"CNI_IFNAME=" + ifname2}, conf2, nil)
 
-			ocicni, err = initCNI(fake, cacheDir, defaultNetName, tmpDir, true, "/opt/cni/bin")
+			ocicni, err = initCNI(fake, cacheDir, defaultNetName, tmpDir, true, testBinDir)
 			Expect(err).NotTo(HaveOccurred())
 
 			podNet = PodNetwork{
-				Name:      "pod1",
-				Namespace: "namespace1",
+				Name:      testPodName,
+				Namespace: testPodNamespace,
 				ID:        containerID,
-				UID:       "9414bd03-b3d3-453e-9d9f-47dcee07958c",
+				UID:       testPodUID,
 				NetNS:     networkNS.Path(),
 			}
 		})
@@ -1193,16 +1202,16 @@ var _ = Describe("ocicni operations", func() {
 		fake.addPlugin(nil, conf1, nil)
 		fake.addPlugin(nil, conf2, nil)
 
-		ocicni, err := initCNI(fake, cacheDir, defaultNetName, tmpDir, true, "/opt/cni/bin")
+		ocicni, err := initCNI(fake, cacheDir, defaultNetName, tmpDir, true, testBinDir)
 		Expect(err).NotTo(HaveOccurred())
 
 		defer Expect(ocicni.Shutdown()).NotTo(HaveOccurred())
 
 		podNet := PodNetwork{
-			Name:      "pod1",
-			Namespace: "namespace1",
+			Name:      testPodName,
+			Namespace: testPodNamespace,
 			ID:        containerID,
-			UID:       "9414bd03-b3d3-453e-9d9f-47dcee07958c",
+			UID:       testPodUID,
 			NetNS:     networkNS.Path(),
 			Networks: []NetAttachment{
 				{Name: netName1},

--- a/pkg/ocicni/types_freebsd.go
+++ b/pkg/ocicni/types_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd
-// +build freebsd
 
 package ocicni
 

--- a/pkg/ocicni/util_freebsd.go
+++ b/pkg/ocicni/util_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd
-// +build freebsd
 
 package ocicni
 
@@ -9,6 +8,8 @@ import (
 	"net"
 	"os/exec"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 type nsManager struct{}
@@ -17,13 +18,13 @@ func (nsm *nsManager) init() error {
 	return nil
 }
 
-func getContainerDetails(ctx context.Context, nsm *nsManager, netnsJailName, interfaceName, addrType string) (*net.IPNet, *net.HardwareAddr, error) {
-	// Try to retrieve ip inside container network namespace
+func getContainerDetails(ctx context.Context, _ *nsManager, netnsJailName, interfaceName, addrType string) (*net.IPNet, *net.HardwareAddr, error) {
 	if addrType == "-4" {
 		addrType = "inet"
 	} else {
 		addrType = "inet6"
 	}
+
 	output, err := exec.CommandContext(ctx,
 		"ifconfig", "-j", netnsJailName,
 		"-f", "inet:cidr,inet6:cidr",
@@ -37,21 +38,23 @@ func getContainerDetails(ctx context.Context, nsm *nsManager, netnsJailName, int
 	if len(lines) < 3 {
 		return nil, nil, fmt.Errorf("unexpected command output %s", output)
 	}
+
 	fields := strings.Fields(strings.TrimSpace(lines[2]))
 	if len(fields) < 2 {
 		return nil, nil, fmt.Errorf("unexpected address output %s ", lines[0])
 	}
+
 	ip, ipNet, err := net.ParseCIDR(fields[1])
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse ip from output %s due to %w", output, err)
 	}
+
 	if ip.To4() == nil {
 		ipNet.IP = ip
 	} else {
 		ipNet.IP = ip.To4()
 	}
 
-	// Try to retrieve MAC inside container network namespace
 	output, err = exec.CommandContext(ctx,
 		"ifconfig", "-j", netnsJailName, "-f", "inet:cidr,inet6:cidr",
 		interfaceName,
@@ -64,10 +67,12 @@ func getContainerDetails(ctx context.Context, nsm *nsManager, netnsJailName, int
 	if len(lines) < 3 {
 		return nil, nil, fmt.Errorf("unexpected ifconfig command output %s", output)
 	}
+
 	fields = strings.Fields(strings.TrimSpace(lines[2]))
 	if len(fields) < 2 {
 		return nil, nil, fmt.Errorf("unexpected ether output %s ", lines[0])
 	}
+
 	mac, err := net.ParseMAC(fields[1])
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse MAC from output %s due to %w", output, err)
@@ -78,8 +83,13 @@ func getContainerDetails(ctx context.Context, nsm *nsManager, netnsJailName, int
 
 func bringUpLoopback(netns string) error {
 	if err := exec.Command("ifconfig", "-j", netns, "lo0", "inet", "127.0.0.1").Run(); err != nil {
-		return fmt.Errorf("failed to initialize loopback: %w", err)
+		return fmt.Errorf("failed to initialize IPv4 loopback: %w", err)
 	}
+
+	if err := exec.Command("ifconfig", "-j", netns, "lo0", "inet6", "::1", "prefixlen", "128").Run(); err != nil {
+		logrus.Debugf("Failed to initialize IPv6 loopback (IPv6 may be disabled): %v", err)
+	}
+
 	return nil
 }
 

--- a/pkg/ocicni/util_unsupported.go
+++ b/pkg/ocicni/util_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package ocicni
 
@@ -9,8 +8,7 @@ import (
 	"net"
 )
 
-type nsManager struct {
-}
+type nsManager struct{}
 
 var errUnsupportedPlatform = errors.New("unsupported platform")
 
@@ -18,15 +16,14 @@ func (nsm *nsManager) init() error {
 	return nil
 }
 
-func getContainerDetails(_ context.Context, nsm *nsManager, netnsPath, interfaceName, addrType string) (*net.IPNet, *net.HardwareAddr, error) {
+func getContainerDetails(_ context.Context, _ *nsManager, _, _, _ string) (*net.IPNet, *net.HardwareAddr, error) {
 	return nil, nil, errUnsupportedPlatform
 }
 
-func bringUpLoopback(netns string) error {
+func bringUpLoopback(_ string) error {
 	return errUnsupportedPlatform
 }
 
-func checkLoopback(netns string) error {
+func checkLoopback(_ string) error {
 	return errUnsupportedPlatform
-
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup
/kind ci

#### What this PR does / why we need it:

- Fix `getContainerDetails` signatures to be consistent across Linux, FreeBSD, and unsupported platforms (add `context.Context` parameter). Previously, `checkNetwork` called `getContainerDetails` with 5 arguments but the FreeBSD and unsupported variants only accepted 4, causing a compile error on non-Linux platforms.
- Use `exec.CommandContext` in FreeBSD for context cancellation support.
- Use `%w` for error wrapping in FreeBSD error formatting.
- Add best-effort IPv6 loopback initialization on FreeBSD.
- Remove unused `tearDownLoopback` from unsupported platform.
- Remove redundant `// +build` tags (covered by `//go:build`).
- Roll back successfully attached networks in reverse order on partial `SetUpPod` failure.
- Continue monitoring on fsnotify errors instead of silently exiting the monitor goroutine.
- Demote verbose pod network log from Info to Debug.
- Add `maxIfaceNum` constant for interface name generation limit.
- Extract repeated test string literals into constants.
- Add cross-platform (freebsd, windows) build CI job.
- Simplify coverage collection using Go built-in profile merging.
- Remove stale Travis CI references from Makefile.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The cross-platform compilation fix is the most important change. CI only tested Linux architectures, so the signature mismatch between `getContainerDetails` on Linux (5 params) vs FreeBSD/unsupported (4 params) went undetected. A new `build-cross-platform` CI job now catches this.

#### Does this PR introduce a user-facing change?

```release-note
Fix cross-platform compilation for FreeBSD and unsupported platforms.
Roll back attached networks on partial SetUpPod failure.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved network setup reliability by rolling back previously attached networks when a later attachment fails.
  - CNI monitoring now logs errors and continues instead of stopping.
  - Improved FreeBSD loopback initialization, including IPv6 support and clearer IPv4 failure reporting.
  - Reduced routine runtime logging noise.

- **Platform Support**
  - Added cross-platform build coverage for FreeBSD and Windows.
  - Updated platform compatibility checks for more reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->